### PR TITLE
update init file to try both options for config

### DIFF
--- a/home_assistant/custom_components/__init__.py
+++ b/home_assistant/custom_components/__init__.py
@@ -4,6 +4,7 @@ import voluptuous as vol
 from homeassistant.const import (CONF_USERNAME, CONF_PASSWORD, CONF_TIME_ZONE)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import discovery
+from homeassistant.components.switch import PLATFORM_SCHEMA
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -18,19 +19,35 @@ CONFIG_SCHEMA = vol.Schema({
     }),
 }, extra=vol.ALLOW_EXTRA)
 
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_USERNAME): cv.string,
+    vol.Required(CONF_PASSWORD): cv.string,
+    vol.Optional(CONF_TIME_ZONE): cv.string,
+})
+
 
 def setup(hass, config):
     """Set up the VeSync component."""
     from pyvesync.vesync import VeSync
 
-    conf = config[DOMAIN]
+    if DOMAIN in config and config[DOMAIN] is not None:
+        conf = config[DOMAIN]
+    else:
+        _LOGGER.info(
+            'You are using config for vesync that is no longer supported. '
+            'Please see https://www.home-assistant.io/components/vesync for '
+            'updated configuration instructions.')
+        conf = next(
+            (i for i in config['switch'] if i['platform'] == 'vesync'),
+            None
+        )
 
     manager = VeSync(conf.get(CONF_USERNAME), conf.get(CONF_PASSWORD),
                      time_zone=conf.get(CONF_TIME_ZONE))
 
     if not manager.login():
         _LOGGER.error("Unable to login to VeSync")
-        return
+        return False
 
     manager.update()
 

--- a/home_assistant/custom_components/switch.py
+++ b/home_assistant/custom_components/switch.py
@@ -1,6 +1,6 @@
 """Support for Etekcity VeSync switches."""
 import logging
-from homeassistant.components.switch import (SwitchDevice)
+from homeassistant.components.switch import SwitchDevice
 
 from . import DOMAIN
 


### PR DESCRIPTION
Attempt at supporting both a switch and component level config within home assistant to not made the update to component level config a breaking change. I am not sure this will pass review when made against the HA repo but it's worth a shot.

This PR will add an info level message if the user is using the legacy platform style config but will still accept the configuration to start up. A future PR should remove the platform style config.