### PR TITLE
Don't throw when response content is empty

### DIFF
--- a/src/pyvesync/helpers.py
+++ b/src/pyvesync/helpers.py
@@ -177,7 +177,8 @@ class Helpers:
         else:
             if r.status_code == 200:
                 status_code = 200
-                response = r.json()
+                if r.content:
+                    response = r.json()
             else:
                 logger.debug('Unable to fetch %s%s', API_BASE_URL, api)
         return response, status_code


### PR DESCRIPTION
VeSync appears to have changed their API and the response from ON\OFF calls is now an empty string (see https://github.com/home-assistant/core/issues/48878 for more details). The fix simply prevents an exception being thrown in this scenario.