### PR TITLE
add support for LAP-C401S-WUSR

### DIFF
--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -51,6 +51,7 @@ _DEVICE_CLASS: Dict[str, Type[VeSyncBaseDevice]] = {
     'Core200S': VeSyncAir200S,
     'Core300S': VeSyncAir300S400S,
     'Core400S': VeSyncAir300S400S,
+    'LAP-C601S-WUS': VeSyncAir300S400S,
     'LUH-D301S-WEU': VeSyncHumid200300S,
     'LAP-C201S-AUSR': VeSyncAir200S,
     'LAP-C401S-WUSR': VeSyncAir300S400S,
@@ -62,7 +63,7 @@ _DEVICE_TYPES_DICT: Dict[str, List[str]] = dict(
     switches=['ESWL01', 'ESWL03', 'ESWD16'],
     fans=['LV-PUR131S', 'Classic200S', 'Classic300S', 'Core200S',
           'Core300S', 'Core400S', 'Dual200S',
-          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR'],
+          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR', 'LAP-C601S-WUS'],
     bulbs=['ESL100', 'ESL100CW'],
 )
 

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -63,7 +63,8 @@ _DEVICE_TYPES_DICT: Dict[str, List[str]] = dict(
     switches=['ESWL01', 'ESWL03', 'ESWD16'],
     fans=['LV-PUR131S', 'Classic200S', 'Classic300S', 'Core200S',
           'Core300S', 'Core400S', 'Dual200S',
-          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR', 'LAP-C601S-WUS'],
+          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR',
+          'LAP-C601S-WUS'],
     bulbs=['ESL100', 'ESL100CW'],
 )
 

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -52,7 +52,8 @@ _DEVICE_CLASS: Dict[str, Type[VeSyncBaseDevice]] = {
     'Core300S': VeSyncAir300S400S,
     'Core400S': VeSyncAir300S400S,
     'LUH-D301S-WEU': VeSyncHumid200300S,
-    'LAP-C201S-AUSR': VeSyncAir200S
+    'LAP-C201S-AUSR': VeSyncAir200S,
+    'LAP-C401S-WUSR': VeSyncAir300S400S,
 }
 
 _DEVICE_TYPES_DICT: Dict[str, List[str]] = dict(
@@ -61,7 +62,7 @@ _DEVICE_TYPES_DICT: Dict[str, List[str]] = dict(
     switches=['ESWL01', 'ESWL03', 'ESWD16'],
     fans=['LV-PUR131S', 'Classic200S', 'Classic300S', 'Core200S',
           'Core300S', 'Core400S', 'Dual200S',
-          'LUH-D301S-WEU', 'LAP-C201S-AUSR'],
+          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR'],
     bulbs=['ESL100', 'ESL100CW'],
 )
 

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -12,7 +12,9 @@ air_features = {
     'Classic200S': [],
     'LUH-D301S-WEU': [],
     'LAP-C201S-AUSR': [],
-    'Classic300S': ['nightlight']
+    'Classic300S': ['nightlight'],
+    'LAP-C401S-WUSR': [],
+    'LAP-C601S-WUS': []
 }
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
I just got one of these. The box says it's a "VeSync Core Pro 400S True HEPA Smart Air Purifier" but in the API it shows up as LAP-C401S-WUSR instead of "Core400S". I added it as an alias and it seems to work.

```
>>> vesync.Helpers.call_api('/cloud/v1/deviceManaged/devices', 'post', headers=vesync.Helpers.req_headers(manager), json=vesync.Helpers.req_body(manager, 'devicelist'))
({'traceId': '0000000000', 'code': 0, 'msg': 'request success', 'result': {'total': 1, 'pageSize': 100, 'pageNo': 1, 'list': [{'deviceRegion': 'US', 'isOwner': True, 'authKey': None, 'deviceName': 'air purifier', 'deviceImg': 'https://image.vesync.com/defaultImages/Core_400S_Series/icon_core400s_purifier_160.png', 'cid': 'vsaqxxxxxxxxxxxxxxxxxxxxxxxxxxxx', 'deviceStatus': 'on', 'connectionStatus': 'online', 'connectionType': 'WiFi+BTOnboarding+BTNotify', 'deviceType': 'LAP-C401S-WUSR', 'type': 'wifi-air', 'uuid': 'xxxxxxxx-xxxx-4xxx-xxxx-xxxxxxxxxxxx', 'configModule': 'WiFiBTOnboardingNotify_AirPurifier_LAP-C401S-WUSR_US', 'macID': '78:e3:6d:xx:xx:xx', 'mode': None, 'speed': None, 'extension': {'airQuality': -1, 'airQualityLevel': 1, 'mode': 'auto', 'fanSpeedLevel': '1'}, 'currentFirmVersion': None, 'subDeviceNo': None, 'subDeviceType': None, 'deviceFirstSetupTime': 'Jan 25, 2022 8:30:51 PM', 'deviceProp': None}]}}, 200)
```