### PR TITLE
Fix API modes for Classic200S humidifier display

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -845,6 +845,10 @@ class VeSyncHumid200300S(VeSyncBaseDevice):
             'display': False,
             'automatic_stop': True
         }
+        self._api_modes = ['getHumidifierStatus', 'setAutomaticStop',
+                           'setSwitch', 'setNightLightBrightness',
+                           'setVirtualLevel', 'setTargetHumidity',
+                           'setHumidityMode', 'setDisplay']
 
     def build_api_dict(self, method: str) -> Tuple[Dict, Dict]:
         """Build humidifier api call header and body.
@@ -853,10 +857,7 @@ class VeSyncHumid200300S(VeSyncBaseDevice):
         'setSwitch', 'setNightLightBrightness', 'setVirtualLevel',
         'setTargetHumidity', 'setHumidityMode'
         """
-        modes = ['getHumidifierStatus', 'setAutomaticStop',
-                 'setSwitch', 'setNightLightBrightness', 'setVirtualLevel',
-                 'setTargetHumidity', 'setHumidityMode', 'setDisplay']
-        if method not in modes:
+        if method not in self._api_modes:
             logger.debug('Invalid mode - %s', method)
             return {}, {}
         head = Helpers.bypass_header()
@@ -1287,6 +1288,9 @@ class VeSyncHumid200S(VeSyncHumid200300S):
     def __init__(self, details, manager):
         """Initialize levoit 200S device class."""
         super().__init__(details, manager)
+        self._api_modes = ['getHumidifierStatus', 'setAutomaticStop',
+                           'setSwitch', 'setVirtualLevel', 'setTargetHumidity',
+                           'setHumidityMode', 'setIndicatorLightSwitch']
 
     def set_display(self, mode: bool) -> bool:
         """Toggle display on/off."""


### PR DESCRIPTION
For https://github.com/webdjoe/pyvesync/issues/114

Tested the display on both my 200S and 300S humidifiers. I was able to control the display light on both. All tests passed when I ran `tox`:
```
% tox
GLOB sdist-make: /Users/jocelyn/git/pyvesync/setup.py
py38 create: /Users/jocelyn/git/pyvesync/.tox/py38
py38 installdeps: pytest
py38 inst: /Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip
py38 installed: attrs==21.4.0,certifi==2021.10.8,charset-normalizer==2.0.12,idna==3.3,iniconfig==1.1.1,packaging==21.3,pluggy==1.0.0,py==1.11.0,pyparsing==3.0.7,pytest==7.0.1,pyvesync @ file:///Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip,requests==2.27.1,tomli==2.0.1,urllib3==1.26.8
py38 run-test-pre: PYTHONHASHSEED='780422609'
py38 run-test: commands[0] | pytest -q
....................................................................................................                                                                                             [100%]
100 passed in 0.88s
pylint create: /Users/jocelyn/git/pyvesync/.tox/pylint
pylint installdeps: pylint
pylint inst: /Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip
pylint installed: astroid==2.9.3,certifi==2021.10.8,charset-normalizer==2.0.12,idna==3.3,isort==5.10.1,lazy-object-proxy==1.7.1,mccabe==0.6.1,platformdirs==2.5.1,pylint==2.12.2,pyvesync @ file:///Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip,requests==2.27.1,toml==0.10.2,typing_extensions==4.1.1,urllib3==1.26.8,wrapt==1.13.3
pylint run-test-pre: PYTHONHASHSEED='780422609'
pylint run-test: commands[0] | pylint src/pyvesync
PYLINTHOME is now '/Users/jocelyn/Library/Caches/pylint' but obsolescent '/Users/jocelyn/.pylint.d' is found; you can safely remove the latter

------------------------------------
Your code has been rated at 10.00/10

lint create: /Users/jocelyn/git/pyvesync/.tox/lint
lint installdeps: flake8, flake8-docstrings
lint inst: /Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip
lint installed: certifi==2021.10.8,charset-normalizer==2.0.12,flake8==4.0.1,flake8-docstrings==1.6.0,idna==3.3,mccabe==0.6.1,pycodestyle==2.8.0,pydocstyle==6.1.1,pyflakes==2.4.0,pyvesync @ file:///Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip,requests==2.27.1,snowballstemmer==2.2.0,urllib3==1.26.8
lint run-test-pre: PYTHONHASHSEED='780422609'
lint run-test: commands[0] | flake8 src/pyvesync
mypy create: /Users/jocelyn/git/pyvesync/.tox/mypy
mypy installdeps: mypy, types-requests
mypy inst: /Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip
mypy installed: certifi==2021.10.8,charset-normalizer==2.0.12,idna==3.3,mypy==0.931,mypy-extensions==0.4.3,pyvesync @ file:///Users/jocelyn/git/pyvesync/.tox/.tmp/package/1/pyvesync-1.4.3.zip,requests==2.27.1,tomli==2.0.1,types-requests==2.27.11,types-urllib3==1.26.10,typing_extensions==4.1.1,urllib3==1.26.8
mypy run-test-pre: PYTHONHASHSEED='780422609'
mypy run-test: commands[0] | mypy src/pyvesync
Success: no issues found in 8 source files
_______________________________________________________________________________________________ summary ________________________________________________________________________________________________
  py38: commands succeeded
  pylint: commands succeeded
  lint: commands succeeded
  mypy: commands succeeded
  congratulations :)
```