### PR TITLE
Support for LAP-C401S-WAAA (Core 400S region SEA)

### DIFF
--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -55,6 +55,7 @@ _DEVICE_CLASS: Dict[str, Type[VeSyncBaseDevice]] = {
     'LUH-D301S-WEU': VeSyncHumid200300S,
     'LAP-C201S-AUSR': VeSyncAir200S,
     'LAP-C401S-WUSR': VeSyncAir300S400S,
+    'LAP-C401S-WAAA': VeSyncAir300S400S
 }
 
 _DEVICE_TYPES_DICT: Dict[str, List[str]] = dict(
@@ -63,7 +64,7 @@ _DEVICE_TYPES_DICT: Dict[str, List[str]] = dict(
     switches=['ESWL01', 'ESWL03', 'ESWD16'],
     fans=['LV-PUR131S', 'Classic200S', 'Classic300S', 'Core200S',
           'Core300S', 'Core400S', 'Dual200S',
-          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR',
+          'LUH-D301S-WEU', 'LAP-C201S-AUSR', 'LAP-C401S-WUSR', 'LAP-C401S-WAAA'
           'LAP-C601S-WUS'],
     bulbs=['ESL100', 'ESL100CW'],
 )

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -14,6 +14,7 @@ air_features = {
     'LAP-C201S-AUSR': [],
     'Classic300S': ['nightlight'],
     'LAP-C401S-WUSR': [],
+    'LAP-C401S-WAAA': [],
     'LAP-C601S-WUS': []
 }
 


### PR DESCRIPTION
Request to add SEA version of Core 400S (LAP-C401S-WAAA).

tried with this script and able to return my Core400S
```
from pyvesync import VeSync
from pprint import pprint

manager = VeSync("xxxxxx", "xxxxxx", "xxxxxx")
manager.login()

# Get/Update Devices from server - populate device lists
manager.update()
manager.get_devices()
pprint(vars(manager))
```


```
{
   "bulbs":[
      
   ],
   "fans":[
      "DevClass":VeSyncAir300S400S,
      "Name":"Puri",
      "Device No":"None",
      "DevStatus":"on",
      "CID":xxxxxxxxxxxxxxxxxxxxxx
   ],
   "outlets":[
      
   ],
   "switches":[
      
   ]
}
```
