### PR TITLE
fix rounding, floats and ints, Improve Debug

### DIFF
--- a/src/pyvesync/helpers.py
+++ b/src/pyvesync/helpers.py
@@ -363,9 +363,9 @@ class Color:
                   s: Union[int, float, str],
                   v: Union[int, float, str]) -> tuple:
         """Check if HSV values are valid."""
-        valid_hue = cls.min_max(h, 0, 360, 360)
-        valid_saturation = cls.min_max(s, 0, 100, 100)
-        valid_value = cls.min_max(v, 0, 100, 100)
+        valid_hue = float(cls.min_max(h, 0, 360, 360))
+        valid_saturation = float(cls.min_max(s, 0, 100, 100))
+        valid_value = float(cls.min_max(v, 0, 100, 100))
         return (
             valid_hue,
             valid_saturation,
@@ -385,7 +385,7 @@ class Color:
     def hsv_to_rgb(hue, saturation, value) -> RGB:
         """Convert HSV to RGB."""
         return RGB(
-            *tuple(round(i * 255) for i in colorsys.hsv_to_rgb(
+            *tuple(round(i * 255, 0) for i in colorsys.hsv_to_rgb(
                 hue / 360,
                 saturation / 100,
                 value / 100
@@ -403,7 +403,7 @@ class Color:
         hsv_factors = [360, 100, 100]
 
         return HSV(
-            int(round(hsv_tuple[0] * hsv_factors[0], 0)),
-            int(round(hsv_tuple[1] * hsv_factors[1], 0)),
-            int(round(hsv_tuple[2] * hsv_factors[2], 0)),
+            float(round(hsv_tuple[0] * hsv_factors[0], 2)),
+            float(round(hsv_tuple[1] * hsv_factors[1], 2)),
+            float(round(hsv_tuple[2] * hsv_factors[2], 0)),
         )

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -70,14 +70,9 @@ class VeSync:  # pylint: disable=function-redefined
 
     def __init__(self, username, password, time_zone=DEFAULT_TZ, debug=False):
         """Initialize VeSync class with username, password and time zone."""
-        self.debug = debug
+        self._debug = debug
         if debug:
-            logger.setLevel(logging.DEBUG)
-            bulb_mods.logger.setLevel(logging.DEBUG)
-            switch_mods.logger.setLevel(logging.DEBUG)
-            outlet_mods.logger.setLevel(logging.DEBUG)
-            fan_mods.logger.setLevel(logging.DEBUG)
-            helpermodule.logger.setLevel(logging.DEBUG)
+            self.debug = debug
         self.username = username
         self.password = password
         self.token = None
@@ -114,6 +109,29 @@ class VeSync:  # pylint: disable=function-redefined
         else:
             self.time_zone = DEFAULT_TZ
             logger.debug('Time zone is not a string')
+
+    @property
+    def debug(self) -> bool:
+        """Return debug flag."""
+        return self._debug
+
+    @debug.setter
+    def debug(self, new_flag: bool) -> None:
+        """Set debug flag."""
+        log_modules = [bulb_mods,
+                       switch_mods,
+                       outlet_mods,
+                       fan_mods,
+                       helpermodule]
+        if new_flag:
+            logger.setLevel(logging.DEBUG)
+            for m in log_modules:
+                m.logger.setLevel(logging.DEBUG)
+        elif new_flag is False:
+            logger.setLevel(logging.WARNING)
+            for m in log_modules:
+                m.logger.setLevel(logging.WARNING)
+        self._debug = new_flag
 
     @property
     def energy_update_interval(self) -> int:

--- a/src/pyvesync/vesyncbulb.py
+++ b/src/pyvesync/vesyncbulb.py
@@ -63,7 +63,7 @@ class VeSyncBulb(VeSyncBaseDevice):
         super().__init__(details, manager)
         self._brightness = int(0)
         self._color_temp = int(0)
-        self._color_value = int(0)
+        self._color_value = float(0)
         self._color_hue = float(0)
         self._color_saturation = float(0)
         self._color_mode: str = ''   # possible: white, color, hsv
@@ -119,32 +119,32 @@ class VeSyncBulb(VeSyncBaseDevice):
         return 0
 
     @property
-    def color_value(self) -> int:
+    def color_value(self) -> float:
         """Return color value of bulb in percent (0-100)."""
         if self.rgb_shift_feature and self._color is not None:
-            return int(self._color.hsv.value)
+            return self._color.hsv.value
         return 0
 
     @property
     def color(self) -> Optional[Color]:
         """Return color of bulb in the form of a dataclass with two attributes.
 
-        self.color.hsv -> (NamedTuple) Hue: int 0-360,
-            Saturation: int 0-100 and Value: int 0-100
-        self.color.rgb -> (NamedTuple) Red: int 0-255,
-            Green: int 0-255 and Blue: int 0-255
+        self.color.hsv -> (NamedTuple) Hue: float 0-360,
+            Saturation: float 0-100 and Value: float 0-100
+        self.color.rgb -> (NamedTuple) Red: float 0-255,
+            Green: float 0-255 and Blue: float 0-255
         """
         if self.rgb_shift_feature is True and self._color is not None:
             return self._color
         return None
 
     @color.setter
-    def color(self, red: Optional[int] = None,
-              green: Optional[int] = None,
-              blue: Optional[int] = None,
-              hue: Optional[int] = None,
-              saturation: Optional[int] = None,
-              value: Optional[int] = None) -> None:
+    def color(self, red: Optional[float] = None,
+              green: Optional[float] = None,
+              blue: Optional[float] = None,
+              hue: Optional[float] = None,
+              saturation: Optional[float] = None,
+              value: Optional[float] = None) -> None:
         self._color = Color(red=red, green=green, blue=blue,
                             hue=hue, saturation=saturation, value=value)
 
@@ -230,7 +230,7 @@ class VeSyncBulb(VeSyncBaseDevice):
                 if self.color is not None:
                     valid_item = getattr(self.color.hsv, itm)
                 else:
-                    logger.debug("No current saturation value, setting to 0")
+                    logger.debug("No current %s value, setting to 0", itm)
                     valid_item = 100
             hsv_dict[itm] = valid_item
         return Color(hue=hsv_dict['hue'], saturation=hsv_dict['saturation'],
@@ -301,9 +301,9 @@ class VeSyncBulb(VeSyncBaseDevice):
             logger.debug("HSV not supported by bulb")
             return False
 
-    def set_rgb(self, red: Optional[int] = None,
-                green: Optional[int] = None,
-                blue: Optional[int] = None) -> bool:
+    def set_rgb(self, red: Optional[float] = None,
+                green: Optional[float] = None,
+                blue: Optional[float] = None) -> bool:
         """Set RGB if supported by bulb. Red 0-255, Green 0-255, Blue 0-255."""
         if self.rgb_shift_feature is False:
             logger.debug("RGB not supported by bulb")
@@ -441,13 +441,13 @@ class VeSyncBulbESL100MC(VeSyncBulb):
         """Set brightness of bulb."""
         return self.set_status(brightness=brightness)
 
-    def set_rgb_color(self, red: int, green: int, blue: int) -> bool:
+    def set_rgb_color(self, red: float, green: float, blue: float) -> bool:
         """Set RGB Color of bulb."""
         return self.set_status(red=red, green=green, blue=blue)
 
-    def set_rgb(self, red: Optional[int] = None,
-                green: Optional[int] = None,
-                blue: Optional[int] = None) -> bool:
+    def set_rgb(self, red: Optional[float] = None,
+                green: Optional[float] = None,
+                blue: Optional[float] = None) -> bool:
         """Set RGB Color of bulb."""
         return self.set_status(red=red, green=green, blue=blue)
 
@@ -490,9 +490,9 @@ class VeSyncBulbESL100MC(VeSyncBulb):
         }
 
         if new_color is not None:
-            body['payload']['data']['red'] = new_color.rgb.red
-            body['payload']['data']['green'] = new_color.rgb.green
-            body['payload']['data']['blue'] = new_color.rgb.blue
+            body['payload']['data']['red'] = int(new_color.rgb.red)
+            body['payload']['data']['green'] = int(new_color.rgb.green)
+            body['payload']['data']['blue'] = int(new_color.rgb.blue)
             body['payload']['data']['colorMode'] = 'color'
 
         if brightness is not None:
@@ -508,9 +508,9 @@ class VeSyncBulbESL100MC(VeSyncBulb):
             logger.debug("Error in setting bulb status")
             return False
         if new_color is not None:
-            self._color = Color(red=new_color.rgb.red,
-                                green=new_color.rgb.green,
-                                blue=new_color.rgb.blue)
+            self._color = Color(red=int(new_color.rgb.red),
+                                green=int(new_color.rgb.green),
+                                blue=int(new_color.rgb.blue))
         if brightness is not None:
             self._brightness = brightness
         self.device_status = 'on'
@@ -832,9 +832,9 @@ class VeSyncBulbValcenoA19MC(VeSyncBulb):
                 self._color_temp = innerresult.get('colorTemp')
             if self.rgb_shift_feature:
                 self._color_mode = innerresult.get('colorMode')
-                hue = int(round(innerresult.get('hue')/27.777777, 0))
-                sat = innerresult.get('saturation')/100
-                val = innerresult.get('value')
+                hue = float(round(innerresult.get('hue')/27.777777, 2))
+                sat = float(innerresult.get('saturation')/100)
+                val = float(innerresult.get('value'))
                 self._color = Color(hue=hue, saturation=sat, value=val)
         elif response.get('code') == -11300030:
             logger.debug('%s device request timeout', self.device_name)
@@ -939,21 +939,22 @@ class VeSyncBulbValcenoA19MC(VeSyncBulb):
         """Set brightness of multicolor bulb."""
         return self.set_status(brightness=brightness)
 
-    def set_color_value(self, color_value: int) -> bool:
-        """Set color value of multicolor bulb."""
-        return self.set_status(color_value=color_value)
-
     def set_color_temp(self, color_temp: int) -> bool:
         """Set White Temperature of Bulb in pct (0 - 100)."""
         return self.set_status(color_temp=color_temp)
 
-    def set_color_saturation(self, color_saturation: int) -> bool:
-        """Set Color Saturation of Bulb in pct (1 - 100)."""
-        return self.set_status(color_saturation=color_saturation)
-
     def set_color_hue(self, color_hue: float) -> bool:
         """Set Color Hue of Bulb (0 - 360)."""
         return self.set_status(color_hue=color_hue)
+
+    def set_color_saturation(self, color_saturation: float) -> bool:
+        """Set Color Saturation of Bulb in pct (1 - 100)."""
+        return self.set_status(color_saturation=color_saturation)
+
+    def set_color_value(self, color_value: float) -> bool:
+        """Set Value of multicolor bulb in pct (1 - 100)."""
+        # Equivalent to brightness level, when in color mode.
+        return self.set_status(color_value=color_value)
 
     def set_color_mode(self, color_mode: str) -> bool:
         """Set Color Mode of Bulb (white / hsv)."""
@@ -979,13 +980,14 @@ class VeSyncBulbValcenoA19MC(VeSyncBulb):
         arg_dict = {
             "hue": hue_update,
             "saturation": sat_update,
-            "value": value_update
+            "brightness": value_update
         }
+        # the api expects the hsv Value in the brightness parameter
 
         if self._color is not None:
             current_dict = {"hue": self.color_hue,
                             "saturation": self.color_saturation,
-                            "value": self.color_value}
+                            "brightness": self.color_value}
             same_colors = True
             for key, val in arg_dict.items():
                 if val != "":
@@ -999,7 +1001,7 @@ class VeSyncBulbValcenoA19MC(VeSyncBulb):
                 arg_dict[key] = int(round(val*27.77778, 0))
             if key == "saturation" and isinstance(val, float):
                 arg_dict[key] = int(round(val*100, 0))
-            if key == "value" and isinstance(val, float):
+            if key == "brightness" and isinstance(val, float):
                 arg_dict[key] = int(round(val, 0))
         arg_dict['colorMode'] = 'hsv'
         return self._set_status_api(arg_dict)
@@ -1022,13 +1024,13 @@ class VeSyncBulbValcenoA19MC(VeSyncBulb):
             brightness between 0 and 100, by default None
         color_temp : int, optional
             color temperature between 0 and 100, by default None
-        color_saturation : int, optional
-            color saturation between 0 and 100, by default None
-        color_hue : float, optional
-            color hue between 0 and 360, by default None
         color_mode : str, optional
             color mode hsv or white, by default None
-        color_value : int, optional
+        color_hue : float, optional
+            color hue between 0 and 360, by default None
+        color_saturation : float, optional
+            color saturation between 0 and 100, by default None
+        color_value : float, optional
             color value between 0 and 100, by default None
 
         Returns


### PR DESCRIPTION
previous PR got closed automatically and by mistake
Re-pushing it again...

I also improved the Debug behavior, now, it's possible to change the `.Debug` property after the first login was made. that was broken before.

Regarding the bulb parameters: everything is `float` now, so that is the common denominator, and each specifc bulb has the logic to convert it to `int` where needed just for the api request. But the pyvesync objects still float, standardized.

I also fixed a broken `set_hsv` and `set_color_value` method, because the API expectes the `Value` paramter in the `brightness` field, but then it send the status back of `Value` in the actual `Value` field, so I fixed the code to be in accordance to that.