### PR TITLE
add support for levoit superior 6000S humidifier 

### DIFF
--- a/src/tests/api/vesyncfan/LEH-S601S-WUS.yaml
+++ b/src/tests/api/vesyncfan/LEH-S601S-WUS.yaml
@@ -1,0 +1,303 @@
+automatic_stop_off:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        workMode: manual
+      method: setHumidityMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+automatic_stop_on:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        workMode: autoPro
+      method: setHumidityMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+set_auto_mode:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        workMode: autoPro
+      method: setHumidityMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+set_drying_mode_enabled:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        autoDryingSwitch: 0
+      method: setDryingMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+set_humidity:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        targetHumidity: 50
+      method: setTargetHumidity
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+set_manual_mode:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        workMode: manual
+      method: setHumidityMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+set_mist_level:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        levelIdx: 0
+        levelType: mist
+        virtualLevel: 2
+      method: setVirtualLevel
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_off:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        powerSwitch: 0
+        switchIdx: 0
+      method: setSwitch
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_off_display:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        screenSwitch: 0
+      method: setDisplay
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_on:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        powerSwitch: 1
+        switchIdx: 0
+      method: setSwitch
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_on_display:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        screenSwitch: 1
+      method: setDisplay
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+update:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LEH-S601S-WUS-CID
+    configModule: ConfigModule
+    debugMode: false
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data: {}
+      method: getHumidifierStatus
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2

--- a/src/tests/call_json_fans.py
+++ b/src/tests/call_json_fans.py
@@ -267,6 +267,45 @@ class FanDetails:
         }
     }, 200)
 
+    details_superior6000S = ({
+        "traceId": Defaults.trace_id,
+        "code": 0,
+        "msg": "request success",
+        "module": None,
+        "stacktrace": None,
+        "result": {
+            "traceId": Defaults.trace_id,
+            "code": 0,
+            "result": {
+            "powerSwitch": 1,
+            "humidity": 44,
+            "targetHumidity": 50,
+            "virtualLevel": 1,
+            "mistLevel": 1,
+            "workMode": "manual",
+            "waterLacksState": 0,
+            "waterTankLifted": 0,
+            "autoStopSwitch": 1,
+            "autoStopState": 0,
+            "screenSwitch": 1,
+            "screenState": 1,
+            "scheduleCount": 0,
+            "timerRemain": 0,
+            "errorCode": 0,
+            "dryingMode": {
+                "dryingLevel": 1,
+                "autoDryingSwitch": 1,
+                "dryingState": 2,
+                "dryingRemain": 7200
+            },
+            "autoPreference": 1,
+            "childLockSwitch": 0,
+            "filterLifePercent": 93,
+            "temperature": 662
+            }
+        }
+    }, 200)
+
 
 DETAILS_RESPONSES = {
     'LV-PUR131S': FanDetails.details_air,
@@ -281,7 +320,8 @@ DETAILS_RESPONSES = {
     'LUH-O451S-WUS': FanDetails.details_lv600s,
     'LAP-V201S-AASR': FanDetails.details_vital100s,
     'LAP-V102S-AASR': FanDetails.details_vital100s,
-    'LUH-M101S-WUS': FanDetails.details_oasismist1000S
+    'LUH-M101S-WUS': FanDetails.details_oasismist1000S,
+    'LEH-S601S-WUS': FanDetails.details_superior6000S
 }
 
 FunctionResponses.default_factory = lambda: ({

--- a/src/tests/test_fans.py
+++ b/src/tests/test_fans.py
@@ -290,7 +290,7 @@ class TestHumidifiers(TestBase):
                     ]
     device_methods = {
         'LUH-A602S-WUSR': [['set_warm_level', {'warm_level': 3}]],
-
+        'LEH-S601S-WUS': [['set_drying_mode_enabled', { 'mode': False }]]
     }
 
     def test_details(self, dev_type, method):


### PR DESCRIPTION
Adds support for the [Levoit superior 6000S](https://levoit.com/products/superior-6000s-smart-evaporative-humidifier) as requested in #214. I own one of these humidifiers and manually tested that all the write apis work. Here's an example of the `display` method:
```
Device Name:.................. Humidifier
Model: ....................... LEH-S601S-WUS
Subdevice No: ................ None
Status: ...................... on
Online: ...................... online
Type: ........................ wifi-air
CID: ......................... REDACTED
UUID: ........................ REDACTED
Temperature................... 662
Humidity: .................... 46 percent
Target Humidity............... 50 percent
Mode: ........................ manual
Mist Virtual Level: .......... 1
Mist Level: .................. 1
Water Lacks: ................. False
Water Tank Lifted: ........... False
Display On: .................. True
Filter Life................... 93 percent
Drying Mode Enabled........... True
Drying Mode State............. off
Drying Mode Level............. low
Drying Mode Time Remaining.... 7200 seconds
``` 

Happy to update this as requested to get merged. I did a decent amount of copypasta here, for which I apologize in advance. 