### PR TITLE
Fix fan timer retrieval

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -319,10 +319,12 @@ class VeSyncAirBypass(VeSyncBaseDevice):
 
         timer = timers[0]
         if self.timer is None:
-            self.timer = Timer(timer_duration=timer.get('duration', 0),
-                               action=timer.get('action'),
-                               id=timer.get('id'),
-                               remaining=timer.get('remaining'))
+            self.timer = Timer(
+                timer_duration=timer.get("duration", timer.get("total", 0)),
+                action=timer.get("action"),
+                id=timer.get("id"),
+                remaining=timer.get("remaining", timer.get("remain"))
+            )
         else:
             self.timer.update(time_remaining=timer.get('remaining'))
         logger.debug('Timer found: %s', str(self.timer))


### PR DESCRIPTION
Hi there,

when quering the timer of my core 200s I noticed that the API response seem to have changed. I get responses that look like the following:#
```
{'id': 1, 'remain': 3455, 'total': 3600, 'action': 'off'}
```

Currently it is expected that "remaining" is passed instead of "remain" and "duration" is used instead of "total". With this MR the remaining and total duration are now extracted correctly from such kind of responses while still supporting the "old" form (just in case)