### PR TITLE
Adding support for 42 inch smart tower fan

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -39,6 +39,7 @@ disable=
     too-many-instance-attributes,
     too-many-lines,
     too-many-locals,
+    too-many-positional-arguments,
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -142,7 +142,7 @@ air_features: dict = {
         'mode_remap': {'manual': 'normal', 'sleep': 'advancedSleep'},
         'set_mode_method': 'setTowerFanMode',
         'get_status_method': 'getTowerFanStatus',
-        'features': ['fan_speed', 'timer'],
+        'features': ['fan_speed'],
         'levels': list(range(1, 13))
     }
 }

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -134,6 +134,15 @@ air_features: dict = {
         'modes': ['manual', 'auto', 'sleep', 'off', 'turbo'],
         'features': ['air_quality', 'fan_rotate'],
         'levels': list(range(1, 4))
+    },
+    'SmartTowerFan': {
+        'module': 'VeSyncAirBaseV2',
+        'models': ['LTF-F422S-KEU', 'LTF-F422S-WUSR', 'LTF-F422_WJP', 'LTF-F422S-WUS'],
+        'modes': ['normal', 'auto', 'turbo', 'off'],
+        'set_mode_method': 'setTowerFanMode',
+        'get_status_method': 'getTowerFanStatus',
+        'features': ['fan_speed', 'timer'],
+        'levels': list(range(1, 13))
     }
 }
 
@@ -933,7 +942,12 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
 
     def get_details(self) -> None:
         """Build API V2 Purifier details dictionary."""
-        head, body = self.build_api_dict('getPurifierStatus')
+        head, body = self.build_api_dict(
+            self._config_dict.get(
+                'get_status_method',
+                'getPurifierStatus',
+            )
+        )
 
         r, _ = Helpers.call_api(
             '/cloud/v2/deviceManaged/bypassV2',
@@ -1304,7 +1318,12 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         if mode == 'off':
             return self.turn_off()
 
-        head, body = self.build_api_dict('setPurifierMode')
+        head, body = self.build_api_dict(
+              self._config_dict.get(
+                  'set_mode_method',
+                  'setPurifierMode',
+              )
+        )
         if not head and not body:
             return False
 

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -136,12 +136,10 @@ air_features: dict = {
         'levels': list(range(1, 4))
     },
     'SmartTowerFan': {
-        'module': 'VeSyncAirBaseV2',
+        'module': 'VeSyncTowerFan',
         'models': ['LTF-F422S-KEU', 'LTF-F422S-WUSR', 'LTF-F422_WJP', 'LTF-F422S-WUS'],
-        'modes': ['manual', 'auto', 'sleep', 'turbo', 'off'],
-        'mode_remap': {'manual': 'normal', 'sleep': 'advancedSleep'},
+        'modes': ['normal', 'auto', 'advancedSleep', 'turbo', 'off'],
         'set_mode_method': 'setTowerFanMode',
-        'get_status_method': 'getTowerFanStatus',
         'features': ['fan_speed'],
         'levels': list(range(1, 13))
     }
@@ -943,12 +941,7 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
 
     def get_details(self) -> None:
         """Build API V2 Purifier details dictionary."""
-        head, body = self.build_api_dict(
-            self._config_dict.get(
-                'get_status_method',
-                'getPurifierStatus',
-            )
-        )
+        head, body = self.build_api_dict('getPurifierStatus')
 
         r, _ = Helpers.call_api(
             '/cloud/v2/deviceManaged/bypassV2',
@@ -1310,8 +1303,6 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
                          mode)
             return False
 
-        mode = self._config_dict.get('mode_remap', {}).get(mode, mode.lower())
-
         # Call change_fan_speed if mode is set to manual
         if mode == 'manual':
             if self.speed is None or self.speed == 0:
@@ -1321,12 +1312,7 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         if mode == 'off':
             return self.turn_off()
 
-        head, body = self.build_api_dict(
-              self._config_dict.get(
-                  'set_mode_method',
-                  'setPurifierMode',
-              )
-        )
+        head, body = self.build_api_dict('setPurifierMode')
         if not head and not body:
             return False
 
@@ -1647,6 +1633,96 @@ class VeSyncAir131(VeSyncBaseDevice):
             }
         )
         return json.dumps(sup_val, indent=4)
+
+
+class VeSyncTowerFan(VeSyncAirBaseV2):
+    """Levoit Tower Fan Device Class."""
+
+    def __init__(self, details: Dict[str, list], manager):
+        """Initialize the VeSync Base API V2 Fan Class."""
+        super().__init__(details, manager)
+
+    def get_details(self) -> None:
+        """Build API V2 Fan details dictionary."""
+        head, body = self.build_api_dict('getTowerFanStatus')
+        r, _ = Helpers.call_api(
+            '/cloud/v2/deviceManaged/bypassV2',
+            method='post',
+            headers=head,
+            json_object=body,
+        )
+        if Helpers.nested_code_check(r) is False or not isinstance(r, dict):
+            logger.debug('Error getting purifier details')
+            self.connection_status = 'offline'
+            return
+
+        inner_result = r.get('result', {}).get('result')
+
+        if inner_result is not None:
+            self.build_purifier_dict(inner_result)
+        else:
+            self.connection_status = 'offline'
+            logger.debug('error in inner result dict from purifier')
+        if inner_result.get('configuration', {}):
+            self.build_config_dict(inner_result.get('configuration', {}))
+
+    def mode_toggle(self, mode: str) -> bool:
+        """Set Levoit Tower Fan purifier mode.
+
+        Parameters
+        ----------
+        mode : str
+            Mode to set purifier to, options are: auto, manual, sleep
+
+        Returns
+        -------
+        bool
+        """
+        if mode.lower() not in [x.lower() for x in self.modes]:
+            logger.debug('Invalid purifier mode used - %s',
+                         mode)
+            return False
+
+        if mode == 'off':
+            return self.turn_off()
+
+        head, body = self.build_api_dict('setTowerFanMode')
+        if not head and not body:
+            return False
+
+        body['deviceId'] = self.cid
+        body['payload']['data'] = {
+            'workMode': mode
+        }
+
+        r, _ = Helpers.call_api(
+            '/cloud/v2/deviceManaged/bypassV2',
+            method='post',
+            headers=head,
+            json_object=body,
+        )
+
+        if Helpers.code_check(r):
+            self.mode = mode
+            return True
+        logger.debug('Error setting purifier mode')
+        return False
+
+    def normal_mode(self):
+        """Set mode to normal."""
+        return self.mode_toggle('normal')
+
+    def manual_mode(self):
+        """Adapter to set mode to normal."""
+        return self.normal_mode()
+
+    def advanced_sleep_mode(self) -> bool:
+        """Set advanced sleep mode."""
+        return self.mode_toggle('advancedSleep')
+
+    def sleep_mode(self) -> bool:
+        """Adapter to set advanced sleep mode."""
+        return self.advanced_sleep_mode()
 
 
 class VeSyncHumid200300S(VeSyncBaseDevice):

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -138,7 +138,8 @@ air_features: dict = {
     'SmartTowerFan': {
         'module': 'VeSyncAirBaseV2',
         'models': ['LTF-F422S-KEU', 'LTF-F422S-WUSR', 'LTF-F422_WJP', 'LTF-F422S-WUS'],
-        'modes': ['normal', 'auto', 'turbo', 'off'],
+        'modes': ['manual', 'auto', 'sleep', 'turbo', 'off'],
+        'mode_remap': {'manual': 'normal', 'sleep': 'advancedSleep'},
         'set_mode_method': 'setTowerFanMode',
         'get_status_method': 'getTowerFanStatus',
         'features': ['fan_speed', 'timer'],
@@ -1309,6 +1310,8 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
                          mode)
             return False
 
+        mode = self._config_dict.get('mode_remap', {}).get(mode, mode.lower())
+
         # Call change_fan_speed if mode is set to manual
         if mode == 'manual':
             if self.speed is None or self.speed == 0:
@@ -1329,7 +1332,7 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
 
         body['deviceId'] = self.cid
         body['payload']['data'] = {
-            'workMode': mode.lower()
+            'workMode': mode
         }
 
         r, _ = Helpers.call_api(

--- a/src/tests/api/vesyncfan/LTF-F422S-KEU.yaml
+++ b/src/tests/api/vesyncfan/LTF-F422S-KEU.yaml
@@ -1,0 +1,165 @@
+change_fan_speed:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LTF-F422S-KEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LTF-F422S-KEU-CID
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        levelIdx: 0
+        levelType: wind
+        manualSpeedLevel: 3
+      method: setLevel
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+manual_mode:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LTF-F422S-KEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LTF-F422S-KEU-CID
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        workMode: normal
+      method: setTowerFanMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+sleep_mode:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LTF-F422S-KEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LTF-F422S-KEU-CID
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        workMode: advancedSleep
+      method: setTowerFanMode
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_off:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LTF-F422S-KEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LTF-F422S-KEU-CID
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        powerSwitch: 0
+        switchIdx: 0
+      method: setSwitch
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_on:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LTF-F422S-KEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LTF-F422S-KEU-CID
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        powerSwitch: 1
+        switchIdx: 0
+      method: setSwitch
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+update:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: LTF-F422S-KEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LTF-F422S-KEU-CID
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data: {}
+      method: getTowerFanStatus
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2

--- a/src/tests/call_json_fans.py
+++ b/src/tests/call_json_fans.py
@@ -335,6 +335,42 @@ class FanDetails:
         },
     }, 200)
 
+    details_towerfan42 = ({
+        "traceId": Defaults.trace_id,
+        "code": 0,
+        "msg": "request success",
+        "module": None,
+        "stacktrace": None,
+        "result": {
+            "traceId": Defaults.trace_id,
+            "code": 0,
+            "result": {
+                "powerSwitch": Defaults.bin_toggle,
+                "workMode": "turbo",
+                "manualSpeedLevel": 3,
+                "fanSpeedLevel": 12,
+                "screenState": Defaults.bin_toggle,
+                "screenSwitch": Defaults.bin_toggle,
+                "oscillationSwitch": Defaults.bin_toggle,
+                "oscillationState": Defaults.bin_toggle,
+                "muteSwitch": Defaults.bin_toggle,
+                "muteState": Defaults.bin_toggle,
+                "timerRemain": 0,
+                "temperature": 750,
+                "sleepPreference": {
+                  "sleepPreferenceType": "default",
+                  "oscillationSwitch": Defaults.bin_toggle,
+                  "initFanSpeedLevel": 0,
+                  "fallAsleepRemain": 0,
+                  "autoChangeFanLevelSwitch": Defaults.bin_toggle
+                },
+                "scheduleCount": 0,
+                "displayingType": 0,
+                "errorCode": 0,
+            }                
+        },
+    }, 200)
+
 
 DETAILS_RESPONSES = {
     "LV-PUR131S": FanDetails.details_air,
@@ -352,6 +388,7 @@ DETAILS_RESPONSES = {
     "LUH-M101S-WUS": FanDetails.details_oasismist1000S,
     "LEH-S601S-WUS": FanDetails.details_superior6000S,
     "LAP-EL551S-AUS": FanDetails.details_everest,
+    "LTF-F422S-KEU": FanDetails.details_towerfan42,
 }
 
 FunctionResponses.default_factory = lambda: (

--- a/src/tests/test_fans.py
+++ b/src/tests/test_fans.py
@@ -329,7 +329,7 @@ class TestHumidifiers(TestBase):
         # Parse mock_api args tuple from arg, kwargs to kwargs
         all_kwargs = parse_args(self.mock_api)
 
-        # Assert request matches recored request or write new records
+        # Assert request matches recorded request or write new records
         assert_test(method_call, all_kwargs, dev_type,
                      self.write_api, self.overwrite)
 

--- a/src/tests/test_fans.py
+++ b/src/tests/test_fans.py
@@ -230,7 +230,7 @@ class TestAirPurifiers(TestBase):
 
         # Assert request matches recored request or write new records
         assert_test(method_call, all_kwargs, dev_type,
-                     self.write_api, self.overwrite)
+                    self.write_api, self.overwrite)
 
 
 class TestHumidifiers(TestBase):


### PR DESCRIPTION
Adds basic support for the 42 inch smart tower fan, it supports more features than I have added here, but I'd like to get feedback on this approach first.

Follows recommendations from https://github.com/webdjoe/pyvesync/issues/242, tested on the EU version of the fan.

I am open this being done by not using `_config_dict` to override methods and modes and doing something else (perhaps a new fan subclass, tho I may need assistance in that case) if that is preferred.

---

Manually tested & confirmed the following work, tests updated to include them as well

 - [x] Normal mode
 - [x] Advanced Sleep Mode
 - [x] Turbo Mode
 - [x] Auto Mode
 - [x] Off Mode
 - [x] Fan Speed Changes
 - [X] Switch Toggle on/off