### PR TITLE
fix(redaction): handle token and account_id outside JSON payload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,17 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: End Users/Desktop',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Topic :: Home Automation',
     ],
     keywords=['iot', 'vesync', 'levoit', 'etekcity', 'cosori', 'valceno'],
     packages=find_packages('src', exclude=['tests', 'test*']),
     package_dir={'': 'src'},
     install_requires=['requests>=2.20.0'],
     extras_require={
-        'dev': ['pytest', 'pytest-cov', 'yaml', 'tox']
+        'dev': ['pytest', 'pytest-cov', 'pyyaml', 'tox']
     },
     python_requires='>=3.9',
 )

--- a/src/pyvesync/helpers.py
+++ b/src/pyvesync/helpers.py
@@ -273,18 +273,20 @@ class Helpers:
         if cls.shouldredact:
             stringvalue = re.sub(
                 (
-                    r'(?i)'
-                    r'((?<=token": ")|'
-                    r'(?<=password": ")|'
-                    r'(?<=email": ")|'
-                    r'(?<=tk": ")|'
-                    r'(?<=accountId": ")|'
-                    r'(?<=authKey": ")|'
-                    r'(?<=uuid": ")|'
-                    r'(?<=cid": "))'
-                    r'[^"]+'
+                    r"(?i)"
+                    r'((?<=token":\s")|'
+                    r'(?<=password":\s")|'
+                    r'(?<=email":\s")|'
+                    r'(?<=tk":\s")|'
+                    r'(?<=accountId":\s")|'
+                    r'(?<=authKey":\s")|'
+                    r'(?<=uuid":\s")|'
+                    r'(?<=cid":\s")|'
+                    r"(?<=token\s)|"
+                    r"(?<=account_id\s))"
+                    r'[^"\s]+'
                 ),
-                '##_REDACTED_##',
+                "##_REDACTED_##",
                 stringvalue,
             )
         return stringvalue


### PR DESCRIPTION
Current implementation only redacts within the logged resp payloads, `token` and `account_id` is also logged after `- DEBUG - Login successful`