### PR TITLE
Add LUH-A601S-AUSW model to to Classic300S

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -10,7 +10,7 @@ from pyvesync.helpers import Helpers, Timer
 humid_features: dict = {
     'Classic300S': {
         'module': 'VeSyncHumid200300S',
-        'models': ['Classic300S', 'LUH-A601S-WUSB'],
+        'models': ['Classic300S', 'LUH-A601S-WUSB', 'LUH-A601S-AUSW'],
         'features': ['nightlight'],
         'mist_modes': ['auto', 'sleep', 'manual'],
         'mist_levels': list(range(1, 10))


### PR DESCRIPTION
This change introduces a new model string for the Classic300S to support the LUH-A601S-AUSW. This is a model I purchased at Walmart.

Prior to diff:

```
>>> manager.debug = True
>>> manager.update()
...
2024-12-22 10:19:10,595 - DEBUG - New device list initialized
2024-12-22 10:19:10,595 - DEBUG - Unknown device named Bedroom Humidifier model LUH-A601S-AUSW
2024-12-22 10:19:10,595 - DEBUG - Error - 'VeSync' object has no attribute 'unknown'
2024-12-22 10:19:10,595 - DEBUG - LUH-A601S-AUSW device not added
```

With this PR:

```
>>> manager.debug = True
>>> manager.update()
...
>>> manager.fans[0]
DevClass: VeSyncHumid200300S,                Name:Bedroom Humidifier, Device No: None,                DevStatus: on, CID: somelongstrong
>>> manager.fans[0].details
>>> {'humidity': 40, 'mist_virtual_level': 5, 'mist_level': 2, 'mode': 'sleep', 'water_lacks': False, 'humidity_high': False, 'water_tank_lifted': False, 'display': False, 'automatic_stop_reach_target': False, 'night_light_brightness': 0}
```