### PR TITLE
fix: 131s add modes

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -120,7 +120,8 @@ air_features: dict = {
         'module': 'VeSyncAir131',
         'models': ['LV-PUR131S', 'LV-RH131S'],
         'modes': ['manual', 'auto', 'sleep', 'off'],
-        'features': ['air_quality']
+        'features': ['air_quality'],
+        'levels': list(range(1, 3))
     },
     'Vital100S': {
         'module': 'VeSyncAirBaseV2',

--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -119,6 +119,7 @@ air_features: dict = {
     'LV-PUR131S': {
         'module': 'VeSyncAir131',
         'models': ['LV-PUR131S', 'LV-RH131S'],
+        'modes': ['manual', 'auto', 'sleep', 'off'],
         'features': ['air_quality']
     },
     'Vital100S': {


### PR DESCRIPTION
Add mode data to 131 data.    It supports, auto, 3 levels sleep and off. 

Example from debug logs: 

```
`2025-01-15 16:16:41,494 - DEBUG - API response: 

  {
  "code": 0,
  "msg": "request success",
  "traceId": "1736983000",
  "screenStatus": "off",
  "filterLife": {
    "change": false,
    "useHour": 962,
    "percent": 76
  },
  "activeTime": 351812,
  "timer": null,
  "scheduleCount": 0,
  "schedule": null,
  "levelNew": 0,
  "airQuality": "excellent",
  "level": null,
  "mode": "sleep",
  "deviceName": "Levoit 131S Air Purifier",
  "currentFirmVersion": "2.0.58",
  "childLock": "off",
  "deviceStatus": "on",
  "deviceImg": "https://image.vesync.com/defaultImages/deviceDefaultImages/airpurifier131_240.png",
  "connectionStatus": "online"
}`
```