### PR TITLE
Update VeSyncHumid200300S device_status on update

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -1988,6 +1988,7 @@ class VeSyncHumid200300S(VeSyncBaseDevice):
     def build_humid_dict(self, dev_dict: Dict[str, str]) -> None:
         """Build humidifier status dictionary."""
         self.enabled = dev_dict.get('enabled')
+        self.device_status = 'on' if self.enabled else 'off'
         self.details['humidity'] = dev_dict.get('humidity', 0)
         self.details['mist_virtual_level'] = dev_dict.get(
             'mist_virtual_level', 0)


### PR DESCRIPTION
Device update can being new `enabled` status which represents if the humidifier is on/off. But device_status still continues to be the original value which seems misleading.

The `device_status` is updated for fan and other humidifier classes.