### PR TITLE
Levoit Superior 6000S to also return auto_humidity like other humidifiers

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -2856,6 +2856,11 @@ class VeSyncSuperior6000S(VeSyncBaseDevice):
         return self.details['temperature']
 
     @property
+    def auto_humidity(self):
+        """Auto target humidity."""
+        return self.config['target_humidity']
+
+    @property
     def target_humidity(self):
         """The target humidity when in humidity mode."""
         return self.details['target_humidity']


### PR DESCRIPTION
With different names being used for target humidity it makes upstream code more complicated.  This offers that same data in the standard name as well. @iprak this is to fix an item reported in the forms around your PR. 