### PR TITLE
Correct firmware for fans

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -373,6 +373,8 @@ class VeSyncAirBypass(VeSyncBaseDevice):
             self.details['air_quality_value'] = dev_dict.get(
                 'air_quality_value', 0)
             self.details['air_quality'] = dev_dict.get('air_quality', 0)
+        self.current_firm_version = r.get('currentFirmVersion', self.current_firm_version)
+
 
     def build_config_dict(self, conf_dict: Dict[str, str]) -> None:
         """Build configuration dict for Bypass purifier.
@@ -1598,6 +1600,7 @@ class VeSyncAir131(VeSyncBaseDevice):
             self.mode = r.get('mode', self.mode)
             self.details['level'] = r.get('level', 0)
             self.details['air_quality'] = r.get('airQuality', 'unknown')
+            self.current_firm_version = r.get('currentFirmVersion', self.current_firm_version)
         else:
             logger.debug('Error getting %s details', self.device_name)
 
@@ -2539,6 +2542,8 @@ class VeSyncSuperior6000S(VeSyncBaseDevice):
         self.details['temperature'] = dev_dict.get('temperature', 0)
         self.details['display'] = dev_dict.get('screenSwitch', None)
         self.details['drying_mode'] = dev_dict.get('dryingMode', {})
+        self.current_firm_version = r.get('currentFirmVersion', self.current_firm_version)
+
 
     def build_config_dict(self, _):
         """Build configuration dict for humidifier."""


### PR DESCRIPTION
My 131 wasn't showing firmware, neither is my Classic300.   

I noticed the 131 contains the firmware within the device call vs the summary call: 

2025-01-18 18:20:58,548 - DEBUG - API response: 

```
  {
  "code": 0,
  "msg": "request success",
  "traceId": "1737249658",
  "screenStatus": "off",
  "filterLife": {
    "change": false,
    "useHour": 1035,
    "percent": 75
  },
  "activeTime": 0,
  "timer": null,
  "scheduleCount": 0,
  "schedule": null,
  "levelNew": 7,
  "airQuality": "excellent",
  "level": 2,
  "mode": "manual",
  "deviceName": "Levoit 131S Air Purifier",
  "currentFirmVersion": "2.0.58",
  "childLock": "off",
  "deviceStatus": "on",
  "deviceImg": "https://image.vesync.com/defaultImages/deviceDefaultImages/airpurifier131_240.png",
  "connectionStatus": "online"
}
```

I couldn't find the data for the classic300 even though it is in the app. 

This PR parses the data - only overwriting if it finds data. 