### PR TITLE
chore:   Github PR title checks

### DIFF
--- a/.github/workflows/PRTitle.yaml
+++ b/.github/workflows/PRTitle.yaml
@@ -1,0 +1,18 @@
+name: "Lint PR"
+
+on:
+    pull_request_target:
+        types:
+            - opened
+            - edited
+            - synchronize
+
+jobs:
+    main:
+        runs-on: ubuntu-latest
+        steps:
+            # Please look up the latest version from
+            # https://github.com/amannn/action-semantic-pull-request/releases
+            - uses: amannn/action-semantic-pull-request@v5.5.3
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/PRTitle.yaml
+++ b/.github/workflows/PRTitle.yaml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: "Semantic Title"
 
 on:
     pull_request_target:
@@ -13,6 +13,6 @@ jobs:
         steps:
             # Please look up the latest version from
             # https://github.com/amannn/action-semantic-pull-request/releases
-            - uses: amannn/action-semantic-pull-request@v5.5.3
+            - uses: amannn/action-semantic-pull-request@v6
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This starts to move toward this: https://github.com/webdjoe/pyvesync/discussions/271  Let me know if that doesn't interest you.  

It checks all PRs to confirm they use semantic titles.   This is important as without it the release code can't detect the notes or create the release.   Examples being fix: chore: feat:  docs: 

This will add an item on PRs like this: 
![image](https://github.com/user-attachments/assets/e3aac557-dad5-45a5-9cae-b3de8b5e41b1)


One setting that I find is important is the merge sittings for PRs to ensure the title is used to squash the commits to a single line. It should be set like this to keep it clean and functional:

![image](https://github.com/user-attachments/assets/13fe1550-8e5c-4a60-85b3-efc3a0c8365d)

Once this is merged I can create a PR for the actual release into pypi.  You would need to add a token to the repo for the upload, I can't add that token. Nor will I be able to see it as setup as secret in the repo. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Introduced an automated check that validates pull request titles follow semantic conventions whenever PRs are opened, edited, or synchronized. This improves repository hygiene and release workflows. No changes to app behavior; end-users are unaffected. Contributors may see status checks on PRs indicating title compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->