### PR TITLE
chore: Auto Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/checkout@v4
             - name: Gets semantic release info
               id: semantic_release_info
-              uses: jossef/action-semantic-release-info@v3
+              uses: jossef/action-semantic-release-info@v3.0.0
               env:
                   GITHUB_TOKEN: ${{ github.token }}
             - name: Update Version and Commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,20 @@ on:
     # Triggers the workflow on push or pull request events but only for the master branch
     schedule:
       - cron: "0 8 * * Sun"
-    workflow_dispatch:
+on:
+  schedule:
+    - cron: "0 8 * * Sun"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  # … rest of your jobs …
     build:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,6 @@
 name: Release
 # Controls when the workflow will run
 on:
-    # Triggers the workflow on push or pull request events but only for the master branch
-    schedule:
-      - cron: "0 8 * * Sun"
-on:
-  schedule:
-    - cron: "0 8 * * Sun"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # … rest of your jobs …
     build:
         runs-on: ubuntu-latest
         steps:
@@ -38,17 +37,16 @@ jobs:
                   github_token: ${{ github.token }}
                   tags: true
             - name: Create GitHub Release
-      - name: Create GitHub Release
-        if: ${{ steps.semantic_release_info.outputs.version != '' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
-          name: ${{ steps.semantic_release_info.outputs.git_tag }}
-          body: ${{ steps.semantic_release_info.outputs.notes }}
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+              if: ${{ steps.semantic_release_info.outputs.version != '' }}
+              uses: softprops/action-gh-release@v2
+              with:
+                tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+                name: ${{ steps.semantic_release_info.outputs.git_tag }}
+                body: ${{ steps.semantic_release_info.outputs.notes }}
+                draft: false
+                prerelease: false
+              env:
+                GITHUB_TOKEN: ${{ github.token }}
             - name: Install dependencies
               if: ${{steps.semantic_release_info.outputs.version != ''}}
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,17 @@ jobs:
                   github_token: ${{ github.token }}
                   tags: true
             - name: Create GitHub Release
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              uses: actions/create-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-              with:
-                  tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
-                  release_name: ${{ steps.semantic_release_info.outputs.git_tag }}
-                  body: ${{ steps.semantic_release_info.outputs.notes }}
-                  draft: false
-                  prerelease: false
+      - name: Create GitHub Release
+        if: ${{ steps.semantic_release_info.outputs.version != '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+          name: ${{ steps.semantic_release_info.outputs.git_tag }}
+          body: ${{ steps.semantic_release_info.outputs.notes }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
             - name: Install dependencies
               if: ${{steps.semantic_release_info.outputs.version != ''}}
               run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,60 +11,60 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - name: Gets semantic release info
-              id: semantic_release_info
-              uses: jossef/action-semantic-release-info@v3.0.0
-              env:
-                  GITHUB_TOKEN: ${{ github.token }}
-            - name: Update Version and Commit
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              run: |
-                  echo "Version: ${{steps.semantic_release_info.outputs.version}}"
-                  sed -i "s/version = \".*\",/version = \"${{steps.semantic_release_info.outputs.version}}\",/g" pyproject.toml
-                  git config --local user.email "action@github.com"
-                  git config --local user.name "GitHub Action"
-                  git add -A
-                  git commit -m "chore: bumping version to ${{steps.semantic_release_info.outputs.version}}"
-                  git tag ${{ steps.semantic_release_info.outputs.git_tag }}
-            - name: Push changes
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              uses: ad-m/github-push-action@v0.8.0
-              with:
-                  github_token: ${{ github.token }}
-                  tags: true
-            - name: Create GitHub Release
-              if: ${{ steps.semantic_release_info.outputs.version != '' }}
-              uses: softprops/action-gh-release@v2
-              with:
-                tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
-                name: ${{ steps.semantic_release_info.outputs.git_tag }}
-                body: ${{ steps.semantic_release_info.outputs.notes }}
-                draft: false
-                prerelease: false
-              env:
-                GITHUB_TOKEN: ${{ github.token }}
-            - name: Install dependencies
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              run: |
-                  python -m pip install --upgrade pip
-                  pip install build
-            - name: Build package
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              run: python -m build
-            - name: Publish package to PyPi Test
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  user: __token__
-                  password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-                  repository_url: https://test.pypi.org/legacy/
-            - name: Publish package to PyPi Live
-              if: ${{steps.semantic_release_info.outputs.version != ''}}
-              uses: pypa/gh-action-pypi-publish@release/v1
-              with:
-                  user: __token__
-                  password: ${{ secrets.PYPI_API_TOKEN }}
+  build:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - name: Gets semantic release info
+          id: semantic_release_info
+          uses: jossef/action-semantic-release-info@v3.0.0
+          env:
+              GITHUB_TOKEN: ${{ github.token }}
+        - name: Update Version and Commit
+          if: ${{steps.semantic_release_info.outputs.version != ''}}
+          run: |
+              echo "Version: ${{steps.semantic_release_info.outputs.version}}"
+              sed -i "s/version = \".*\",/version = \"${{steps.semantic_release_info.outputs.version}}\",/g" pyproject.toml
+              git config --local user.email "action@github.com"
+              git config --local user.name "GitHub Action"
+              git add -A
+              git commit -m "chore: bumping version to ${{steps.semantic_release_info.outputs.version}}"
+              git tag ${{ steps.semantic_release_info.outputs.git_tag }}
+        - name: Push changes
+          if: ${{steps.semantic_release_info.outputs.version != ''}}
+          uses: ad-m/github-push-action@v0.8.0
+          with:
+              github_token: ${{ github.token }}
+              tags: true
+        - name: Create GitHub Release
+          if: ${{ steps.semantic_release_info.outputs.version != '' }}
+          uses: softprops/action-gh-release@v2
+          with:
+            tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+            name: ${{ steps.semantic_release_info.outputs.git_tag }}
+            body: ${{ steps.semantic_release_info.outputs.notes }}
+            draft: false
+            prerelease: false
+          env:
+            GITHUB_TOKEN: ${{ github.token }}
+        - name: Install dependencies
+          if: ${{steps.semantic_release_info.outputs.version != ''}}
+          run: |
+              python -m pip install --upgrade pip
+              pip install build
+        - name: Build package
+          if: ${{steps.semantic_release_info.outputs.version != ''}}
+          run: python -m build
+        - name: Publish package to PyPi Test
+          if: ${{steps.semantic_release_info.outputs.version != ''}}
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+              user: __token__
+              password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+              repository_url: https://test.pypi.org/legacy/
+        - name: Publish package to PyPi Live
+          if: ${{steps.semantic_release_info.outputs.version != ''}}
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+              user: __token__
+              password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+# Controls when the workflow will run
+on:
+    # Triggers the workflow on push or pull request events but only for the master branch
+    schedule:
+      - cron: "0 8 * * Sun"
+    workflow_dispatch:
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Gets semantic release info
+              id: semantic_release_info
+              uses: jossef/action-semantic-release-info@v2
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+            - name: Update Version and Commit
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              run: |
+                  echo "Version: ${{steps.semantic_release_info.outputs.version}}"
+                  sed -i "s/version=\".*\",/version=\"${{steps.semantic_release_info.outputs.version}}\",/g" setup.py
+                  git config --local user.email "action@github.com"
+                  git config --local user.name "GitHub Action"
+                  git add -A
+                  git commit -m "chore: bumping version to ${{steps.semantic_release_info.outputs.version}}"
+                  git tag ${{ steps.semantic_release_info.outputs.git_tag }}
+            - name: Push changes
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: ad-m/github-push-action@v0.8.0
+              with:
+                  github_token: ${{ github.token }}
+                  tags: true
+            - name: Create GitHub Release
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+                  release_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+                  body: ${{ steps.semantic_release_info.outputs.notes }}
+                  draft: false
+                  prerelease: false
+            - name: Install dependencies
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install build
+            - name: Build package
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              run: python -m build
+            - name: Publish package to PyPi Test
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70
+              with:
+                  user: __token__
+                  password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+                  repository_url: https://test.pypi.org/legacy/
+            - name: Publish package to PyPi Live
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70
+              with:
+                  user: __token__
+                  password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
             - uses: actions/checkout@v4
             - name: Gets semantic release info
               id: semantic_release_info
-              uses: jossef/action-semantic-release-info@v2
+              uses: jossef/action-semantic-release-info@v3
               env:
                   GITHUB_TOKEN: ${{ github.token }}
             - name: Update Version and Commit
@@ -52,14 +52,14 @@ jobs:
               run: python -m build
             - name: Publish package to PyPi Test
               if: ${{steps.semantic_release_info.outputs.version != ''}}
-              uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   user: __token__
                   password: ${{ secrets.TEST_PYPI_API_TOKEN }}
                   repository_url: https://test.pypi.org/legacy/
             - name: Publish package to PyPi Live
               if: ${{steps.semantic_release_info.outputs.version != ''}}
-              uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70
+              uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   user: __token__
                   password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
               if: ${{steps.semantic_release_info.outputs.version != ''}}
               run: |
                   echo "Version: ${{steps.semantic_release_info.outputs.version}}"
-                  sed -i "s/version=\".*\",/version=\"${{steps.semantic_release_info.outputs.version}}\",/g" setup.py
+                  sed -i "s/version = \".*\",/version = \"${{steps.semantic_release_info.outputs.version}}\",/g" pyproject.toml
                   git config --local user.email "action@github.com"
                   git config --local user.name "GitHub Action"
                   git add -A


### PR DESCRIPTION
This action will auto release every sunday morning to pypi. It will bundle all changes with a semantic title into it and generate release notes for it.  These naturally are only merged PRs.  Interval can be easily changed or forced by yourself using the actions tab.  

Versions auto increment in setup.py using this and match in the repo release.   Breaking changes increase the 1.X.X.  Features X.1.X and fixes the last octet x.x.1. 

For this to function secrets must be created in the repo using tokens from pypi.  They would be Action Repo secrets like this: 

![image](https://github.com/user-attachments/assets/3026c0d0-37ff-440e-9c39-01d71f89f093)


This requires #272.  As that confirms a title exists before merging. Without a title that is valid a release won't occur.   

This may need some tweaking to get it right since I can't test.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manually-triggered release workflow (no scheduled runs).
  * Detects new versions and updates project versioning, creates tags and GitHub Releases with release notes.
  * Builds the package and publishes artifacts to Test PyPI and PyPI when a new version is found.
  * Enforces concurrency control, scoped repository permissions, and uses repository secrets for publishing.
  * Post-release steps only run when a semantic version is produced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->