### PR TITLE
set_night_light_brightness: show correct failure message

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -2253,7 +2253,7 @@ class VeSyncHumid200300S(VeSyncBaseDevice):
 
         if r is not None and Helpers.code_check(r):
             return True
-        logger.debug('Error setting humidity')
+        logger.debug('Error setting night light brightness')
         return False
 
     def set_humidity_mode(self, mode: str) -> bool:


### PR DESCRIPTION
A small fix in the debug message. It was confusing me why humidity was being reported as failing while setting night light level.