### PR TITLE
fix: Humidifier Screen incorrect

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -2210,13 +2210,7 @@ class VeSyncHumid200300S(VeSyncBaseDevice):
     @property
     def display_state(self) -> bool:
         """Get display state."""
-        # The field 'display' is defined both on 'config' (in build_config_dict) and
-        # 'details' (in build_humid_dict). get_details first calls build_humid_dict
-        # and then build_config_dict if the result has configuration populated. Based
-        # on this, the values in cofig seem to be an override. We will first check
-        # config and then fall back to details
-        value = self.config.get('display', None)
-        return self.details.get('display', False) if value is None else value
+        return bool(self.details['display'])
 
     def set_humidity(self, humidity: int) -> bool:
         """Set target 200S/300S Humidifier humidity."""


### PR DESCRIPTION
I found humidifier screen state was wrong.

Config value doesn't get updated when it changes.   Not sure if it should?   I am not clear why config and details have things that appear to be duplicate.  

My test code shows the following while the display is off. 

```
Device Name: Humidifier,                  Device Type: Classic300S,                 SubDevice No.: None,                 Status: on
config.display:True
details.display:False
display_state:True
```

This was from running:

```
device = manager.fans[1]
print(device)
print("config.display:" + str(rgetattr(device, "config.display")))
print("details.display:" + str(rgetattr(device, "details.display")))
print("display_state:" + str(device.display_state))
```

With this change display state is corrected. 
