### PR TITLE
Add alias for LV-RH131S-WM

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -118,7 +118,7 @@ air_features: dict = {
     },
     'LV-PUR131S': {
         'module': 'VeSyncAir131',
-        'models': ['LV-PUR131S', 'LV-RH131S'],
+        'models': ['LV-PUR131S', 'LV-RH131S', 'LV-RH131S-WM'],
         'modes': ['manual', 'auto', 'sleep', 'off'],
         'features': ['air_quality'],
         'levels': list(range(1, 3))


### PR DESCRIPTION
Add model alias LV-RH131S-WM for LV-PUR131S

Fixes https://github.com/webdjoe/pyvesync/issues/300