### PR TITLE
fix: 131s display

### DIFF
--- a/src/pyvesync/vesyncfan.py
+++ b/src/pyvesync/vesyncfan.py
@@ -1691,6 +1691,7 @@ class VeSyncAir131(VeSyncBaseDevice):
             return False
         head = Helpers.req_headers(self.manager)
         body = Helpers.req_body(self.manager, 'devicestatus')
+        body['uuid'] = self.uuid
         body['status'] = status.lower()
         r, _ = Helpers.call_api(
             '/131airPurifier/v1/device/updateScreen', 'put',


### PR DESCRIPTION
This solves #304 it now functions correctly.  This matches how turn_on and turn_off function for the 131s. 