### PR TITLE
fix deprecated import error

### DIFF
--- a/src/pyvesync/devices/vesyncbulb.py
+++ b/src/pyvesync/devices/vesyncbulb.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
-from deprecated import deprecated
+from typing_extensions import deprecated
 from pyvesync.base_devices import VeSyncBulb
 from pyvesync.const import DeviceStatus, ConnectionStatus
 from pyvesync.models.base_models import DefaultValues

--- a/src/pyvesync/devices/vesyncswitch.py
+++ b/src/pyvesync/devices/vesyncswitch.py
@@ -25,7 +25,7 @@ from dataclasses import asdict
 import logging
 # from abc import ABCMeta, abstractmethod
 from typing import TYPE_CHECKING
-from deprecated import deprecated
+from typing_extensions import deprecated
 
 from pyvesync.base_devices.switch_base import VeSyncSwitch
 from pyvesync.utils.colors import Color


### PR DESCRIPTION
Use of wrong deprecated library causing missing requirement.