### PR TITLE
Fix night light state for v1 purifiers

### DIFF
--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -134,8 +134,7 @@ class VeSyncAirBypass(BypassV2Mixin, VeSyncPurifier):
             self.state.pm25 = result.air_quality_value
             self.state.set_air_quality_level(result.air_quality)
         if result.night_light is not None:
-            self.state.nightlight_status = DeviceStatus.ON if result.night_light \
-                else DeviceStatus.OFF
+            self.state.nightlight_status = DeviceStatus(result.night_light)
 
     async def get_details(self) -> None:
         r_dict = await self.call_bypassv2_api('getPurifierStatus')


### PR DESCRIPTION
## Issue
Purifiers using the `VeSyncAirBypass` class  (mainly Core 200S/300S/400S/600S) will always have the `state.nightlight_status` be `ON`, regardless of the actual state.

## Reason
`_set_purifier_state` sets the night light state like this:
```
self.state.nightlight_status = DeviceStatus.ON if result.night_light else DeviceStatus.OFF
```
Since `result.night_light` is a `on`/`off` string, this will always evaluate to `DeviceStatus.ON` if set, regardless of the value.

## Note
**I can't test this with a physical device. This PR is based on mocked data which may not be 100% accurate.**