### PR TITLE
Clarify failed login scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ async def main():
         # To print logs to file
         manager.log_to_file("pyvesync.log")
 
-        await manager.login()  # Still returns true
+        await manager.login()
         if not manager.enabled:
             print("Not logged in.")
             return
@@ -187,7 +187,7 @@ The [raise_api_errors()](https://webdjoe.github.io/pyvesync/latest/development/u
 - `VeSyncRateLimitError` - The API's rate limit has been exceeded.
 - `VeSyncAPIStatusCodeError` - The API returned a non-200 status code.
 - `VeSyncTokenError` - The API returned a token error and requires `login()` to be called again.
-- `VeSyncLoginError` - The user name or password is incorrect.
+- `VeSyncLoginError` - The username or password is incorrect.
 
 ## Installation
 
@@ -274,7 +274,7 @@ from pyvesync.logs import VeSyncLoginError
 
 async def main():
     async with VeSync("user", "password") as manager:
-        await manager.login()  # Still returns true
+        await manager.login()
         await manager.update()
 
         # Acts as a set of device instances
@@ -345,7 +345,7 @@ async def main():
     async with VeSync("user", "password") as manager:
         manager.debug = True
         manager.redact = True  # True by default
-        await manager.login()  # Still returns true
+        await manager.login()
         await manager.update()
 
         outlet = manager.outlets[0]
@@ -405,7 +405,7 @@ DEVICE_NAME = "Device" # Device to test
 async def test_device():
     # Instantiate VeSync class and login
   async with VeSync(USERNAME, PASSWORD, debug=True, redact=True) as manager:
-      login = await manager.login()
+      await manager.login()
 
       # Pull and update devices
       await manager.update()

--- a/src/pyvesync/utils/errors.py
+++ b/src/pyvesync/utils/errors.py
@@ -787,7 +787,7 @@ class VeSyncError(Exception):
     """
 
 
-class VesyncLoginError(VeSyncError):
+class VeSyncLoginError(VeSyncError):
     """Exception raised for login authentication errors."""
 
     def __init__(self, msg: str) -> None:
@@ -855,7 +855,7 @@ def raise_api_errors(error_info: ResponseInfo) -> None:
         case ErrorTypes.RATE_LIMIT:
             raise VeSyncRateLimitError
         case ErrorTypes.AUTHENTICATION:
-            raise VesyncLoginError(error_info.message)
+            raise VeSyncLoginError(error_info.message)
         case ErrorTypes.TOKEN_ERROR:
             raise VeSyncTokenError
         case ErrorTypes.SERVER_ERROR:

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -39,7 +39,7 @@ from pyvesync.utils.errors import (
     VeSyncAPIStatusCodeError,
     VeSyncError,
     VeSyncServerError,
-    VesyncLoginError,
+    VeSyncLoginError,
     raise_api_errors,
     )
 
@@ -317,7 +317,7 @@ class VeSync:  # pylint: disable=function-redefined
         """
         if not isinstance(self.username, str) or len(self.username) == 0 \
                 or not isinstance(self.password, str) or len(self.password) == 0:
-            raise VesyncLoginError('Username and password must be specified')
+            raise VeSyncLoginError('Username and password must be specified')
 
         request_auth = RequestAuthModel(
             email=self.username,
@@ -408,7 +408,7 @@ class VeSync:  # pylint: disable=function-redefined
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:
                     error_info.message = f'{error_info.message} ({resp_message})'
-                raise VesyncLoginError(
+                raise VeSyncLoginError(
                     f"Error receiving response to login request - {error_info.message}"
                 )
 

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -310,17 +310,15 @@ class VeSync:  # pylint: disable=function-redefined
 
         Username and password are provided when class is instantiated.
 
-        Returns:
-            True if login successful, False if not.
-
         Raises:
-            VeSyncLoginError: If login fails due to invalid username or password.
+            VeSyncLoginError: If login fails, for example due to invalid username or password.
             VeSyncAPIResponseError: If API response is invalid.
             VeSyncServerError: If server returns an error.
         """
         if not isinstance(self.username, str) or len(self.username) == 0 \
                 or not isinstance(self.password, str) or len(self.password) == 0:
             raise VesyncLoginError('Username and password must be specified')
+
         request_auth = RequestAuthModel(
             email=self.username,
             method='authByPWDOrOTM',
@@ -332,27 +330,33 @@ class VeSync:  # pylint: disable=function-redefined
         )
         if resp_dict is None:
             raise VeSyncAPIResponseError('Error receiving response to auth request')
-        if resp_dict.get('code') == 0:
-            try:
-                response_model = ResponseLoginModel.from_dict(resp_dict)
-            except Exception as exc:
-                logger.debug('Error parsing auth response: %s', exc)
-                raise VeSyncAPIResponseError(
-                    'Error receiving response to auth request'
-                    ) from exc
-            result = response_model.result
-            if isinstance(result, IntRespAuthResultModel):
-                # If the result is an IntRespAuthResultModel,
-                # we need to log in with the auth code
-                return await self._login_token(auth_code=result.authorizeCode)
 
-        error_info = ErrorCodes.get_error_info(resp_dict.get("code"))
-        resp_message = resp_dict.get('msg')
-        if resp_message is not None:
-            error_info.message = f'{error_info.message} ({resp_message})'
-        raise VeSyncAPIResponseError(
-            f"Error receiving response to auth request - {error_info.message}"
-        )
+        if not resp_dict.get('code') == 0:
+            error_info = ErrorCodes.get_error_info(resp_dict.get("code"))
+            resp_message = resp_dict.get('msg')
+            if resp_message is not None:
+                error_info.message = f'{error_info.message} ({resp_message})'
+            raise VeSyncAPIResponseError(
+                f"Error receiving response to auth request - {error_info.message}"
+            )
+
+        try:
+            response_model = ResponseLoginModel.from_dict(resp_dict)
+        except Exception as exc:
+            logger.debug('Error parsing auth response: %s', exc)
+            raise VeSyncAPIResponseError(
+                'Error receiving response to auth request'
+            ) from exc
+
+        result = response_model.result
+        if not isinstance(result, IntRespAuthResultModel):
+            raise VeSyncAPIResponseError(
+                "Error receiving response to login request -"
+                " result is not IntRespAuthResultModel"
+            )
+
+        await self._login_token(auth_code=result.authorizeCode)
+
 
     async def _login_token(
             self,
@@ -370,11 +374,8 @@ class VeSync:  # pylint: disable=function-redefined
             region_change_token (str): "bizToken" to use when calling this endpoint
                 for a second time with a different region.
 
-        Returns:
-            True if login successful, False if not.
-
         Raises:
-            VeSyncLoginError: If login fails due to invalid username or password.
+            VeSyncLoginError: If login fails, for example due to invalid username or password.
             VeSyncAPIResponseError: If API response is invalid.
             VeSyncServerError: If server returns an error.
         """
@@ -398,30 +399,32 @@ class VeSync:  # pylint: disable=function-redefined
                     "Error receiving response to login request -"
                     "result is not IntRespLoginResultModel"
                 )
-            if response_model.code == 0:
-                result = response_model.result
-                if not isinstance(result, IntRespLoginResultModel):
-                    raise VeSyncAPIResponseError(
-                        "Error receiving response to login request -"
-                        " result is not IntRespLoginResultModel"
-                    )
-                self._token = result.token
-                self._account_id = result.accountID
-                self.country_code = result.countryCode
-                self.enabled = True
-                logger.debug('Login successful')
-                return True
-            error_info = ErrorCodes.get_error_info(resp_dict.get("code"))
-            if error_info.error_type == ErrorTypes.CROSS_REGION:  # "cross region error."
-                result = response_model.result
-                self.country_code = result.countryCode
-                return await self._login_token(region_change_token=result.bizToken)
-            resp_message = resp_dict.get('msg')
-            if resp_message is not None:
-                error_info.message = f'{error_info.message} ({resp_message})'
-            raise VesyncLoginError(
-                f"Error receiving response to login request - {error_info.message}"
-            )
+            if not response_model.code == 0:
+                error_info = ErrorCodes.get_error_info(resp_dict.get("code"))
+                if error_info.error_type == ErrorTypes.CROSS_REGION:  # "cross region error."
+                    result = response_model.result
+                    self.country_code = result.countryCode
+                    await self._login_token(region_change_token=result.bizToken)
+                resp_message = resp_dict.get('msg')
+                if resp_message is not None:
+                    error_info.message = f'{error_info.message} ({resp_message})'
+                raise VesyncLoginError(
+                    f"Error receiving response to login request - {error_info.message}"
+                )
+
+            result = response_model.result
+            if not isinstance(result, IntRespLoginResultModel):
+                raise VeSyncAPIResponseError(
+                    "Error receiving response to login request -"
+                    " result is not IntRespLoginResultModel"
+                )
+
+            self._token = result.token
+            self._account_id = result.accountID
+            self.country_code = result.countryCode
+            self.enabled = True
+            logger.debug('Login successful')
+
         except (MissingField, UnserializableDataError) as exc:
             logger.debug('Error parsing login response: %s', exc)
             raise VeSyncAPIResponseError(

--- a/src/tests/test_x_vesync_login.py
+++ b/src/tests/test_x_vesync_login.py
@@ -2,7 +2,7 @@
 import pytest
 import orjson
 
-from pyvesync.utils.errors import VesyncLoginError
+from pyvesync.utils.errors import VeSyncLoginError
 from pyvesync import const
 from pyvesync.models.vesync_models import ResponseLoginModel
 
@@ -49,7 +49,7 @@ class TestLogin(TestApiFunc):
             status=200,
             response=orjson.dumps(INVALID_PASSWORD_RESP),
         )
-        with pytest.raises(VesyncLoginError):
+        with pytest.raises(VeSyncLoginError):
             self.run_in_loop(self.manager.login)
 
     def test_good_login_response(self):

--- a/testing_scripts/vs_test_script.py
+++ b/testing_scripts/vs_test_script.py
@@ -115,10 +115,7 @@ async def vesync_test(
     logger.info("VeSync instance created, logging to %s", output_path)
     # Login to VeSync account and check for success
     logger.info("Logging in to VeSync account...")
-    success = await vs.login()
-    if not success:
-        logger.error("Login failed.")
-        return
+    await vs.login()
     logger.info("Login successful, pulling device list...")
     await _random_await()
 


### PR DESCRIPTION
## Issue

The new implementation of the login flow always raises an exception when login fails, but the login method still returns `bool`.
The effective return value will always be `True`.

## Changes

- Removed all return values for `VeSync.login()` and related methods
- Use fail-fast design for `login`/`_login_token` to improve readability
- Rename `VesyncLoginError` to `VeSyncLoginError` for consistency

## Notes

If you still need to check if login was successful (for example if ignoring all raised exceptions), you can check `manager.enabled` as documented in `README.md`.