### PR TITLE
Fix setting display state when light detection is turned on

### DIFF
--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -1,7 +1,6 @@
 """VeSync API for controlling air purifiers."""
 from __future__ import annotations
 import logging
-import asyncio
 from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
@@ -592,8 +591,8 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
 
     async def toggle_display(self, mode: bool) -> bool:
         if bool(self.state.light_detection_status):
-            await self.toggle_light_detection(False)  # Ensure light detection is off
-            await asyncio.sleep(1) # Wait for a second - the setDisplay call fails when called immediately after disabling light detection
+            _LOGGER.error('Cannot set display when light detection is enabled')
+            return False
 
         if bool(self.state.display_set_status) == mode:
             _LOGGER.debug('Display is already %s', mode)

--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -1,6 +1,7 @@
 """VeSync API for controlling air purifiers."""
 from __future__ import annotations
 import logging
+import asyncio
 from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
@@ -528,6 +529,10 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
 
     async def toggle_light_detection(self, toggle: bool | None = None) -> bool:
         """Enable/Disable Light Detection Feature."""
+        if bool(self.state.light_detection_status) == toggle:
+            _LOGGER.debug('Light detection is already %s', self.state.light_detection_status)
+            return True
+
         if toggle is None:
             toggle = not bool(self.state.light_detection_status)
         payload_data = {"lightDetectionSwitch": int(toggle)}
@@ -536,8 +541,7 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         if r is None:
             return False
 
-        self.state.light_detection_switch = DeviceStatus.ON if toggle \
-            else DeviceStatus.OFF
+        self.state.light_detection_switch = DeviceStatus.from_bool(toggle)
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
@@ -587,6 +591,10 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         return True
 
     async def toggle_display(self, mode: bool) -> bool:
+        if bool(self.state.light_detection_status):
+            await self.toggle_light_detection(False)  # Ensure light detection is off
+            await asyncio.sleep(1) # Wait for a second - the setDisplay call fails when called immediately after disabling light detection
+
         if bool(self.state.display_set_status) == mode:
             _LOGGER.debug('Display is already %s', mode)
             return True

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -307,7 +307,7 @@ class VeSync:  # pylint: disable=function-redefined
 
         return proc_return
 
-    async def login(self) -> bool:  # pylint: disable=W9006 # pylint mult docstring raises
+    async def login(self) -> None:  # pylint: disable=W9006 # pylint mult docstring raises
         """Log into VeSync server.
 
         Username and password are provided when class is instantiated.
@@ -364,7 +364,7 @@ class VeSync:  # pylint: disable=function-redefined
             self,
             auth_code: str | None = None,
             region_change_token: str | None = None,
-    ) -> bool:  # pylint: disable=W9006 # pylint mult docstring raises
+    ) -> None:  # pylint: disable=W9006 # pylint mult docstring raises
         """Exchanges the authorization code for a token.
 
         This completes the login process. If the initial call fails with
@@ -407,7 +407,7 @@ class VeSync:  # pylint: disable=function-redefined
                 if error_info.error_type == ErrorTypes.CROSS_REGION:  # cross region error
                     result = response_model.result
                     self.country_code = result.countryCode
-                    await self._login_token(region_change_token=result.bizToken)
+                    return await self._login_token(region_change_token=result.bizToken)
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:
                     error_info.message = f'{error_info.message} ({resp_message})'
@@ -427,6 +427,7 @@ class VeSync:  # pylint: disable=function-redefined
             self.country_code = result.countryCode
             self.enabled = True
             logger.debug('Login successful')
+            return None
 
         except (MissingField, UnserializableDataError) as exc:
             logger.debug('Error parsing login response: %s', exc)

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -427,7 +427,6 @@ class VeSync:  # pylint: disable=function-redefined
             self.country_code = result.countryCode
             self.enabled = True
             logger.debug('Login successful')
-            return None
 
         except (MissingField, UnserializableDataError) as exc:
             logger.debug('Error parsing login response: %s', exc)


### PR DESCRIPTION
When light detection is turned on, it controls the display status.
If trying to set the display status while light detection is on, the API responds with error "11017000 (BYPASS_NOT_SUPPORTED)".

As a fix, the `toggle_display` method now checks the light detection status and turns it off if necessary before setting the display status.

Testing (on Levoit Vital 100S) has shown that there is a small delay when disabling light detection before the display can be set - I added a 1 second delay in that case which was enough time in my case.

---

I included another small change regarding the login methods that I missed in #348 which fixes a cross-region error being thrown even though login was successful.