### PR TITLE
fix smart tower fan set modes and get details

### DIFF
--- a/src/pyvesync/devices/vesyncfan.py
+++ b/src/pyvesync/devices/vesyncfan.py
@@ -116,7 +116,7 @@ class VeSyncTowerFan(BypassV2Mixin, VeSyncFanBase):
         payload_data = {
             "workMode": mode
         }
-        r_dict = await self.call_bypassv2_api("setTowerFanStatus", payload_data)
+        r_dict = await self.call_bypassv2_api("setTowerFanMode", payload_data)
         r = Helpers.process_dev_response(logger, "set_mode", self, r_dict)
         if r is None:
             return False

--- a/src/pyvesync/models/fan_models.py
+++ b/src/pyvesync/models/fan_models.py
@@ -15,9 +15,8 @@ from pyvesync.models.bypass_models import (
 
 @dataclass
 class TowerFanResult(BypassV2InnerResult):
-    """Vital 100S/200S and Everest Fan Result Model."""
+    """Tower Fan Result Model."""
     powerSwitch: int
-    filterLifePercent: int
     workMode: str
     manualSpeedLevel: int
     fanSpeedLevel: int


### PR DESCRIPTION
Retitle the model details and remove the filter result as this is a fan not a filter.  Related to #354.

Also fixed modes based on this: https://github.com/webdjoe/pyvesync/blob/047f4cb09753fe00c89759b1d5f8b1601a721ea8/src/pyvesync/vesyncfan.py#L1912C43-L1912C58