### PR TITLE
fix: smart tower fan

### DIFF
--- a/src/pyvesync/devices/vesyncfan.py
+++ b/src/pyvesync/devices/vesyncfan.py
@@ -38,9 +38,7 @@ class VeSyncTowerFan(BypassV2Mixin, VeSyncFanBase):
         self.state.mode = res.workMode
         self.state.fan_level = res.fanSpeedLevel
         self.state.fan_set_level = res.manualSpeedLevel
-        self.state.humidity = res.humidity
         self.state.temperature = res.temperature
-        self.state.thermal_comfort = res.thermalComfort
 
         self.state.mute_status = DeviceStatus.from_int(res.muteState)
         self.state.mute_set_status = DeviceStatus.from_int(res.muteSwitch)


### PR DESCRIPTION
Set fan state errors on non data that doesn't exist.

Related to the previous PRs I fixed but failing now on tests in HA. 