### PR TITLE
Add support for WhogPlug (GreenSun)

### DIFF
--- a/src/tests/api/vesyncoutlet/WHOGPLUG.yaml
+++ b/src/tests/api/vesyncoutlet/WHOGPLUG.yaml
@@ -1,0 +1,73 @@
+get_details:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: WHOGPLUG-CID
+    configModule: ConfigModule
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data: {}
+      method: getOutletStatus
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_off:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: WHOGPLUG-CID
+    configModule: ConfigModule
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        enabled: false
+        id: 0
+      method: setSwitch
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_on:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 2.8.6
+    cid: WHOGPLUG-CID
+    configModule: ConfigModule
+    deviceRegion: US
+    method: bypassV2
+    payload:
+      data:
+        enabled: true
+        id: 0
+      method: setSwitch
+      source: APP
+    phoneBrand: SM N9005
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2

--- a/src/tests/call_json_outlets.py
+++ b/src/tests/call_json_outlets.py
@@ -142,6 +142,27 @@ class OutletDetails:
         }
     }, 200)
 
+    whogplug_details = ({
+        "traceId": "1756897836280",
+        "code": 0,
+        "msg": "request success",
+        "module": None,
+        "stacktrace": None,
+        "result": {
+            "traceId": "1756897836280",
+            "code": 0,
+            "result": {
+                "enabled": False,
+                "voltage": 1,
+                "energy": 1,
+                "power": 1,
+                "current": 1,
+                "highestVoltage": 1,
+                "voltagePtStatus": False
+            }
+        }
+    }, 200)
+
 
 DETAILS_RESPONSES = {
     'wifi-switch-1.3': OutletDetails.details_7a,
@@ -149,7 +170,8 @@ DETAILS_RESPONSES = {
     'ESW01-EU': OutletDetails.details_10a,
     'ESW15-USA': OutletDetails.details_15a,
     'ESO15-TB': OutletDetails.details_outdoor,
-    'BSDOG01': OutletDetails.bsdgo1_details
+    'BSDOG01': OutletDetails.bsdgo1_details,
+    'WHOGPLUG': OutletDetails.whogplug_details
 }
 
 ENERGY_HISTORY = (
@@ -177,6 +199,16 @@ for k in METHOD_RESPONSES:
 
 # Add BSDGO1 specific responses
 METHOD_RESPONSES['BSDOG01'] = defaultdict(lambda: ({
+    "code": 0,
+    "msg": "request success",
+    "result": {
+        "traceId": Defaults.trace_id,
+        "code": 0
+    }
+}, 200))
+
+# Add WhogPlug specific responses
+METHOD_RESPONSES['WHOGPLUG'] = defaultdict(lambda: ({
     "code": 0,
     "msg": "request success",
     "result": {

--- a/src/tests/test_outlets.py
+++ b/src/tests/test_outlets.py
@@ -272,7 +272,7 @@ class TestOutlets(TestBase):
             return
         assert method_call() is False
 
-    @pytest.mark.parametrize('dev_type', [d for d in OUTLET_DEV_TYPES if d != 'BSDOG01'])
+    @pytest.mark.parametrize('dev_type', [d for d in OUTLET_DEV_TYPES if d not in ['BSDOG01', 'WHOGPLUG']])
     def test_power(self, dev_type):
         """Test outlets power history methods."""
         self.mock_api.return_value = call_json_outlets.ENERGY_HISTORY

--- a/src/tests/test_x_vesync_whogplug.py
+++ b/src/tests/test_x_vesync_whogplug.py
@@ -1,0 +1,112 @@
+"""Test scripts for WHOGPLUG Outlets."""
+
+import pytest
+from unittest.mock import patch
+import logging
+from pyvesync import VeSync
+from pyvesync.vesyncoutlet import VeSyncOutletWhogPlug
+from pyvesync.helpers import Helpers as helpers
+import call_json
+import call_json_outlets
+from utils import Defaults, TestBase
+
+DEVICE_TYPE = 'WHOGPLUG'
+
+DEV_LIST_DETAIL = call_json.DeviceList.device_list_item(DEVICE_TYPE)
+
+CORRECT_WHOGPLUG_LIST = call_json.DeviceList.device_list_response(DEVICE_TYPE)
+
+CORRECT_WHOGPLUG_DETAILS = call_json_outlets.DETAILS_RESPONSES[DEVICE_TYPE]
+
+BAD_WHOGPLUG_LIST = call_json.DETAILS_BADCODE
+
+
+class TestVeSyncWhogPlugSwitch(TestBase):
+    """Test WhogPlug outlet API."""
+
+    def test_whogplug_conf(self):
+        """Test initialization of WhogPlug outlet."""
+        self.mock_api.return_value = CORRECT_WHOGPLUG_LIST
+        self.manager.get_devices()
+        outlets = self.manager.outlets
+        assert len(outlets) == 1
+        whogplug_outlet = outlets[0]
+        assert isinstance(whogplug_outlet, VeSyncOutletWhogPlug)
+        assert whogplug_outlet.device_name == call_json.Defaults.name(DEVICE_TYPE)
+        assert whogplug_outlet.device_type == DEVICE_TYPE
+        assert whogplug_outlet.cid == call_json.Defaults.cid(DEVICE_TYPE)
+        assert whogplug_outlet.uuid == call_json.Defaults.uuid(DEVICE_TYPE)
+
+    def test_whogplug_details(self):
+        """Test WhogPlug get_details()."""
+        self.mock_api.return_value = CORRECT_WHOGPLUG_DETAILS
+        whogplug_outlet = VeSyncOutletWhogPlug(DEV_LIST_DETAIL, self.manager)
+        whogplug_outlet.get_details()
+        response = CORRECT_WHOGPLUG_DETAILS[0]
+        result = response.get('result', {})
+        
+        expected_status = 'on' if result.get('enabled') else 'off'
+        assert whogplug_outlet.device_status == expected_status
+        assert whogplug_outlet.power == 1
+        assert whogplug_outlet.voltage == 1
+        assert whogplug_outlet.energy_today == 1
+
+    def test_whogplug_details_fail(self):
+        """Test WhogPlug get_details with bad response."""
+        self.mock_api.return_value = BAD_WHOGPLUG_LIST
+        whogplug_outlet = VeSyncOutletWhogPlug(DEV_LIST_DETAIL, self.manager)
+        whogplug_outlet.get_details()
+        assert len(self.caplog.records) == 1
+        assert 'details' in self.caplog.text
+
+    def test_whogplug_onoff(self):
+        """Test WhogPlug Device On/Off Methods."""
+        self.mock_api.return_value = ({'code': 0}, 200)
+        whogplug_outlet = VeSyncOutletWhogPlug(DEV_LIST_DETAIL, self.manager)
+        head = helpers.req_header_bypass()
+        body = helpers.req_body(self.manager, 'bypassV2')
+        body['cid'] = whogplug_outlet.cid
+        body['configModule'] = whogplug_outlet.config_module
+        
+        # Test turn_on
+        body['payload'] = {
+            'data': {
+                'enabled': True,
+                'id': 0
+            },
+            'method': 'setSwitch',
+            'source': 'APP'
+        }
+        on = whogplug_outlet.turn_on()
+        self.mock_api.assert_called_with(
+            '/cloud/v2/deviceManaged/bypassV2',
+            'post',
+            headers=head,
+            json_object=body
+        )
+        assert on
+        
+        # Test turn_off
+        body['payload'] = {
+            'data': {
+                'enabled': False,
+                'id': 0
+            },
+            'method': 'setSwitch',
+            'source': 'APP'
+        }
+        off = whogplug_outlet.turn_off()
+        self.mock_api.assert_called_with(
+            '/cloud/v2/deviceManaged/bypassV2',
+            'post',
+            headers=head,
+            json_object=body
+        )
+        assert off
+
+    def test_whogplug_onoff_fail(self):
+        """Test WhogPlug On/Off Fail with bad response."""
+        self.mock_api.return_value = BAD_WHOGPLUG_LIST
+        bsdgo1_outlet = VeSyncOutletWhogPlug(DEV_LIST_DETAIL, self.manager)
+        assert not bsdgo1_outlet.turn_on()
+        assert not bsdgo1_outlet.turn_off() 

--- a/src/tests/test_x_vesync_whogplug.py
+++ b/src/tests/test_x_vesync_whogplug.py
@@ -43,7 +43,7 @@ class TestVeSyncWhogPlugSwitch(TestBase):
         whogplug_outlet = VeSyncOutletWhogPlug(DEV_LIST_DETAIL, self.manager)
         whogplug_outlet.get_details()
         response = CORRECT_WHOGPLUG_DETAILS[0]
-        result = response.get('result', {})
+        result = response.get('result', {}).get('result', {})
         
         expected_status = 'on' if result.get('enabled') else 'off'
         assert whogplug_outlet.device_status == expected_status


### PR DESCRIPTION
This pull request adds initial support for the VeSync WhogPlug smart plug (GreenSun).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for the WhogPlug smart outlet.
  - View outlet status (on/off), power, voltage, and daily energy.
  - Turn the outlet on/off via the integration.

- Tests
  - Added unit tests and API specs covering WhogPlug behavior (details, on/off, failure cases).
  - Updated power tests to exclude BSDOG01 and WHOGPLUG device types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->