### PR TITLE
fix: Support for legacy Auth

### DIFF
--- a/src/pyvesync/models/vesync_models.py
+++ b/src/pyvesync/models/vesync_models.py
@@ -23,6 +23,8 @@ from pyvesync.models.base_models import (
     ResponseCodeModel,
 )
 
+from pyvesync.const import USER_TYPE
+
 
 @dataclass
 class RequestGetTokenModel(RequestBaseModel):

--- a/src/pyvesync/models/vesync_models.py
+++ b/src/pyvesync/models/vesync_models.py
@@ -105,7 +105,7 @@ class RequestLoginTokenModel(RequestBaseModel):
         if d['bizToken'] is None:
             d.pop('bizToken')
         return d
-    
+
 @dataclass
 class RequestLoginLegacy(RequestBaseModel):
     """Request model for login."""

--- a/src/pyvesync/models/vesync_models.py
+++ b/src/pyvesync/models/vesync_models.py
@@ -22,6 +22,7 @@ from pyvesync.models.base_models import (
     ResponseBaseModel,
     ResponseCodeModel,
 )
+from tests.call_json import USER_TYPE
 
 
 @dataclass
@@ -103,6 +104,29 @@ class RequestLoginTokenModel(RequestBaseModel):
         if d['bizToken'] is None:
             d.pop('bizToken')
         return d
+    
+@dataclass
+class RequestLoginLegacy(RequestBaseModel):
+    """Request model for login."""
+
+    # Arguments to set
+    email: str
+    password: str
+    # default values
+    devToken: str = ''
+    method: str = "login"
+    userType: str = USER_TYPE
+    acceptLanguage: str = DefaultValues.acceptLanguage
+    timeZone: str = DefaultValues.timeZone
+
+    def __post_init__(self) -> None:
+        """Hash the password field."""
+        self.password = self.hash_password(self.password)
+
+    @staticmethod
+    def hash_password(string: str) -> str:
+        """Encode password."""
+        return hashlib.md5(string.encode('utf-8')).hexdigest()  # noqa: S324
 
 
 @dataclass

--- a/src/pyvesync/models/vesync_models.py
+++ b/src/pyvesync/models/vesync_models.py
@@ -22,7 +22,6 @@ from pyvesync.models.base_models import (
     ResponseBaseModel,
     ResponseCodeModel,
 )
-from tests.call_json import USER_TYPE
 
 
 @dataclass

--- a/src/pyvesync/models/vesync_models.py
+++ b/src/pyvesync/models/vesync_models.py
@@ -119,6 +119,10 @@ class RequestLoginLegacy(RequestBaseModel):
     userType: str = USER_TYPE
     acceptLanguage: str = DefaultValues.acceptLanguage
     timeZone: str = DefaultValues.timeZone
+    phoneBrand: str = DefaultValues.phoneBrand
+    phoneOS: str = DefaultValues.phoneOS
+    appVersion: str = DefaultValues.appVersion
+    traceId: str = field(default_factory=DefaultValues.newTraceId)
 
     def __post_init__(self) -> None:
         """Hash the password field."""

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -331,7 +331,6 @@ class VeSync:  # pylint: disable=function-redefined
             email=self.username,
             method='authByPWDOrOTM',
             password=self.password,
-            userCountryCode=self.country_code,
         )
         resp_dict, _ = await self.async_call_api(
             '/globalPlatform/api/accountAuth/v1/authByPWDOrOTM',

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -413,7 +413,7 @@ class VeSync:  # pylint: disable=function-redefined
                 if error_info.error_type == ErrorTypes.CROSS_REGION:
                     result = response_model.result
                     self.country_code = result.countryCode
-                    return await self._login_token(region_change_token=result.bizToken)
+                    return await self._login_token(region_change_token=result.bizToken, auth_code=auth_code)
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:
                     error_info.message = f'{error_info.message} ({resp_message})'

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -382,7 +382,7 @@ class VeSync:  # pylint: disable=function-redefined
             json_object=request_auth
         )
 
-        if Helpers.code_check(resp_dict) and 'result' in resp_dict:
+        if resp_dict.get('code') == 0 and 'result' in resp_dict:
             self._token = resp_dict.get('result').get('token')
             self._account_id = resp_dict.get('result').get('accountID')
             self.country_code = resp_dict.get('result').get('countryCode')

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -70,6 +70,7 @@ class VeSync:  # pylint: disable=function-redefined
         'session',
         'time_zone',
         'username',
+        '_login_attempts',
     )
 
     def __init__(  # noqa: PLR0913

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -33,6 +33,7 @@ from pyvesync.models.vesync_models import (
     ResponseDeviceListModel,
     ResponseFirmwareModel,
     ResponseLoginModel,
+    RequestLoginLegacy,
 )
 from pyvesync.utils.errors import (
     ErrorCodes,
@@ -364,8 +365,35 @@ class VeSync:  # pylint: disable=function-redefined
                 ' result is not IntRespAuthResultModel'
             )
 
-        return await self._login_token(auth_code=result.authorizeCode)
+        await self._login_token(auth_code=result.authorizeCode)
+    
+    async def _legacy_login(self) -> None:
+        """Log into VeSync server using the legacy approach.
 
+        """
+
+        request_auth = RequestLoginLegacy(
+            email=self.username,
+            password=self.password,
+        )
+
+        resp_dict, _ = await self.async_call_api(
+            '/cloud/v1/user/login', 'post',
+            json_object=request_auth
+        )
+
+        if Helpers.code_check(resp_dict) and 'result' in resp_dict:
+            self._token = resp_dict.get('result').get('token')
+            self._account_id = resp_dict.get('result').get('accountID')
+            self.country_code = resp_dict.get('result').get('countryCode')
+            self.enabled = True
+            logger.debug('Login successful')
+            logger.debug('token %s', self.token)
+            logger.debug('account_id %s', self.account_id)
+
+        logger.error('Error logging in with username and password')
+        raise VeSyncAPIResponseError(resp_dict)
+    
     async def _login_token(
         self,
         auth_code: str | None = None,
@@ -417,12 +445,10 @@ class VeSync:  # pylint: disable=function-redefined
                     result = response_model.result
                     self.country_code = result.countryCode
                     self._login_attempts += 1
-                    if self._login_attempts > 2:
-                        raise VeSyncLoginError(
-                            'Maximum login attempts exceeded,'
-                            ' please check your country code'
-                        )
-                    return await self.login()
+                    if self._login_attempts == 1:
+                        await self._legacy_login()  
+                    else:
+                        await self.login()
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:
                     error_info.message = f'{error_info.message} ({resp_message})'

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -330,6 +330,7 @@ class VeSync:  # pylint: disable=function-redefined
             email=self.username,
             method='authByPWDOrOTM',
             password=self.password,
+            userCountryCode=self.country_code,
         )
         resp_dict, _ = await self.async_call_api(
             '/globalPlatform/api/accountAuth/v1/authByPWDOrOTM',

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -366,7 +366,7 @@ class VeSync:  # pylint: disable=function-redefined
             )
 
         await self._login_token(auth_code=result.authorizeCode)
-    
+
     async def _legacy_login(self) -> None:
         """Log into VeSync server using the legacy approach.
 
@@ -393,7 +393,7 @@ class VeSync:  # pylint: disable=function-redefined
 
         logger.error('Error logging in with username and password')
         raise VeSyncAPIResponseError(resp_dict)
-    
+
     async def _login_token(
         self,
         auth_code: str | None = None,
@@ -446,7 +446,7 @@ class VeSync:  # pylint: disable=function-redefined
                     self.country_code = result.countryCode
                     self._login_attempts += 1
                     if self._login_attempts == 1:
-                        return await self.login()  
+                        return await self.login()
                     else:
                         return await self._legacy_login()
                 resp_message = resp_dict.get('msg')

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -445,7 +445,7 @@ class VeSync:  # pylint: disable=function-redefined
                     self.country_code = result.countryCode
                     self._login_attempts += 1
                     if self._login_attempts == 1:
-                        return await self.login()
+                        return await self._login_token(region_change_token=result.bizToken)
                     else:
                         return await self._legacy_login()
                 resp_message = resp_dict.get('msg')

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -155,7 +155,7 @@ class VeSync:  # pylint: disable=function-redefined
         self.enabled = False
         self.in_process = False
         self._device_container: DeviceContainer = DeviceContainerInstance
-        self._login_attempts = 0
+        self._login_attempts: int = 0
 
     @property
     def devices(self) -> DeviceContainer:

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -446,9 +446,9 @@ class VeSync:  # pylint: disable=function-redefined
                     self.country_code = result.countryCode
                     self._login_attempts += 1
                     if self._login_attempts == 1:
-                        await self.login()  
+                        return await self.login()  
                     else:
-                        await self._legacy_login()
+                        return await self._legacy_login()
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:
                     error_info.message = f'{error_info.message} ({resp_message})'

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -446,9 +446,9 @@ class VeSync:  # pylint: disable=function-redefined
                     self.country_code = result.countryCode
                     self._login_attempts += 1
                     if self._login_attempts == 1:
-                        await self._legacy_login()  
+                        await self.login()  
                     else:
-                        await self.login()
+                        await self._legacy_login()
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:
                     error_info.message = f'{error_info.message} ({resp_message})'

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -448,6 +448,7 @@ class VeSync:  # pylint: disable=function-redefined
                     if self._login_attempts == 1:
                         return await self._login_token(region_change_token=result.bizToken)
                     else:
+                        self.country_code = DEFAULT_REGION
                         return await self._legacy_login()
                 resp_message = resp_dict.get('msg')
                 if resp_message is not None:

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -389,6 +389,7 @@ class VeSync:  # pylint: disable=function-redefined
             logger.debug('Login successful')
             logger.debug('token %s', self.token)
             logger.debug('account_id %s', self.account_id)
+            return None
 
         logger.error('Error logging in with username and password')
         raise VeSyncAPIResponseError(resp_dict)


### PR DESCRIPTION
Not functional just yet but thinking of falling back to legacy auth when redirect occurs too many times.   

For some reason getting illegal argument from the API when I try: manager._legacy_login() as a test.  