### PR TITLE
fix: core300s fan speeds

### DIFF
--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -750,7 +750,7 @@ purifier_modules: list[PurifierMap] = [
             PurifierAutoPreference.QUIET,
         ],
         features=[PurifierFeatures.AIR_QUALITY],
-        fan_levels=list(range(1, 5)),
+        fan_levels=list(range(1, 4)),
         device_alias='Core 300S',
         model_display='Core 300S',
         model_name='Core 300S',


### PR DESCRIPTION
the Core300 only has 3 fan speeds not 4.  This is referenced in a few spots:

https://github.com/home-assistant/core/issues/153641
Pictures from here: https://levoit.com/products/core-300s-p-smart-air-purifier
And the old code before the re-write in HA shows:

<img width="586" height="290" alt="image" src="https://github.com/user-attachments/assets/3fe35449-34ea-4d54-a546-c6b9d84ba49b" />
