### PR TITLE
fix: map sprout devices to sprout class

### DIFF
--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -888,7 +888,7 @@ purifier_modules: list[PurifierMap] = [
         setup_entry='EL551S',
     ),
     PurifierMap(
-        class_name='VeSyncAirBaseV2',
+        class_name='VeSyncAirSprout',
         dev_types=[
             'LAP-B851S-WEU',
             'LAP-B851S-WNA',


### PR DESCRIPTION
The sprout devices aren't being mapped to the sprout class currently.  

https://github.com/webdjoe/pyvesync/pull/332