### PR TITLE
chore:  run tests when PR is targeting dev

### DIFF
--- a/.github/workflows/RunTest.yaml
+++ b/.github/workflows/RunTest.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - dev
   push:
   workflow_dispatch:
 


### PR DESCRIPTION
Right now tests only run when you target master.  This will cause them to run in both cases. 