### PR TITLE
fix: Handle no devices

### DIFF
--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -403,6 +403,9 @@ class VeSync:  # pylint: disable=function-redefined
     async def update_all_devices(self) -> None:
         """Run `get_details()` for each device and update state."""
         logger.debug('Start updating the device details one by one')
+        if len(self._device_container) == 0:
+            logger.error('No devices to update')
+            return
         update_tasks: list[asyncio.Task] = [
             asyncio.create_task(device.update()) for device in self._device_container
         ]
@@ -410,7 +413,7 @@ class VeSync:  # pylint: disable=function-redefined
         for task in done:
             exc = task.exception()
             if exc is not None and isinstance(exc, VeSyncError):
-                logger.debug('Error updating device: %s', exc)
+                logger.error('Error updating device: %s', exc)
 
     async def __aenter__(self) -> Self:
         """Asynchronous context manager enter."""


### PR DESCRIPTION
I have noticed if you call manager.update() without devices it will fail with a really strange error. 

```
    await manager.update_all_devices()
  File "C:\Users\user\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\pyvesync\vesync.py", line 409, in update_all_devices
    done, _ = await asyncio.wait(update_tasks, return_when=asyncio.ALL_COMPLETED)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.11_3.11.2544.0_x64__qbz5n2kfra8p0\Lib\asyncio\tasks.py", line 418, in wait
    raise ValueError('Set of Tasks/Futures is empty.')
ValueError: Set of Tasks/Futures is empty.
```

This can be mimicked by calling update_all_devices() without using a get_devices call which HA uses after it calls get_devices.

I saw one user report this issue, I suspect they had no devices in the first place.  This should make those logs more clear.  It also uses the .error logging level so that it will show in HA logs directly.  More use of that would be handy. 

Now this presents like this: 

```
2025-10-11 20:29:32 - DEBUG - pyvesync.auth - Login successful for user: email@email.com
2025-10-11 20:29:32 - DEBUG - pyvesync.vesync - Start updating the device details one by one
2025-10-11 20:29:32 - ERROR - pyvesync.vesync - No devices to update
```