### PR TITLE
fix:  Disconnecting VeSyncAirBypass Devices

### DIFF
--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -123,6 +123,7 @@ class VeSyncAirBypass(BypassV2Mixin, VeSyncPurifier):
             result (InnerPurifierResult): Data model for inner result in purifier
                 details response.
         """
+        self.state.connection_status = ConnectionStatus.ONLINE
         self.state.device_status = DeviceStatus.ON if result.enabled else DeviceStatus.OFF
         self.state.filter_life = result.filter_life or 0
         self.state.mode = result.mode

--- a/src/pyvesync/utils/device_mixins.py
+++ b/src/pyvesync/utils/device_mixins.py
@@ -193,6 +193,8 @@ def process_bypassv2_result(
     if error_info.error_type != ErrorTypes.SUCCESS:
         _handle_bypass_error(logger, device, method, error_info, resp_dict['code'])
         return None
+    else:
+        device.state.connection_status = ConnectionStatus.from_bool(True)
     result = _get_inner_result(device, logger, method, resp_dict)
     if not isinstance(result, dict):
         return None

--- a/src/pyvesync/utils/device_mixins.py
+++ b/src/pyvesync/utils/device_mixins.py
@@ -193,8 +193,6 @@ def process_bypassv2_result(
     if error_info.error_type != ErrorTypes.SUCCESS:
         _handle_bypass_error(logger, device, method, error_info, resp_dict['code'])
         return None
-    else:
-        device.state.connection_status = ConnectionStatus.from_bool(True)
     result = _get_inner_result(device, logger, method, resp_dict)
     if not isinstance(result, dict):
         return None

--- a/src/pyvesync/utils/device_mixins.py
+++ b/src/pyvesync/utils/device_mixins.py
@@ -196,7 +196,6 @@ def process_bypassv2_result(
     result = _get_inner_result(device, logger, method, resp_dict)
     if not isinstance(result, dict):
         return None
-    device.state.connection_status = ConnectionStatus.from_bool(True)
     return Helpers.model_maker(logger, model, method, result, device)
 
 

--- a/src/pyvesync/utils/device_mixins.py
+++ b/src/pyvesync/utils/device_mixins.py
@@ -193,8 +193,7 @@ def process_bypassv2_result(
     if error_info.error_type != ErrorTypes.SUCCESS:
         _handle_bypass_error(logger, device, method, error_info, resp_dict['code'])
         return None
-    else:
-        device.state.connection_status = ConnectionStatus.from_bool(True)
+    device.state.connection_status = ConnectionStatus.from_bool(True)
     result = _get_inner_result(device, logger, method, resp_dict)
     if not isinstance(result, dict):
         return None

--- a/src/pyvesync/utils/device_mixins.py
+++ b/src/pyvesync/utils/device_mixins.py
@@ -193,10 +193,10 @@ def process_bypassv2_result(
     if error_info.error_type != ErrorTypes.SUCCESS:
         _handle_bypass_error(logger, device, method, error_info, resp_dict['code'])
         return None
-    device.state.connection_status = ConnectionStatus.from_bool(True)
     result = _get_inner_result(device, logger, method, resp_dict)
     if not isinstance(result, dict):
         return None
+    device.state.connection_status = ConnectionStatus.from_bool(True)
     return Helpers.model_maker(logger, model, method, result, device)
 
 


### PR DESCRIPTION
The bypassv2 currently checks for errors in the response. If an error code is received the device connection is set to offline/false.  

bypass doesn't have a connection status in the json response when working correctly like other APIs do such as the 131.   As such the connection status never comes back online.    This then causes HA to filter the device as "unavailable".    

I haven't been able to fully test this theory yet, going to do so shortly.  Its alot of waiting game.  I will post back when confirmed fixed with this. 

#370 