### PR TITLE
chore: dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Enable version updates for Python
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Github actions and requirements should be kept up to date to ensure security and bug fixes are addressed.  This will open pull requests when it detects them being out of date.   

Only done weekly since daily is too much. :)  Example of what the PR should look like:

https://github.com/Hyundai-Kia-Connect/kia_uvo/pull/1298