### PR TITLE
chore: auto release

### DIFF
--- a/.github/workflows/PRTitle.yaml
+++ b/.github/workflows/PRTitle.yaml
@@ -1,9 +1,11 @@
 name: "Semantic Title"
 
 on:
-  push:
-    branches:
-      - master
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/PRTitle.yaml
+++ b/.github/workflows/PRTitle.yaml
@@ -1,11 +1,9 @@
 name: "Semantic Title"
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
+  push:
+    branches:
+      - master
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,8 @@ name: Release
 on:
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
-    schedule:
-        # Runs at 8:00 AM UTC every day
-        - cron: "0 8 * * *"
+            
+
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 # Controls when the workflow will run
 on:
-    # Allows you to run this workflow manually from the Actions tab
-    workflow_dispatch:
-            
+    push:
+        branches:
+            - master
+
 
 jobs:
     build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+# Controls when the workflow will run
+on:
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
+    schedule:
+        # Runs at 8:00 AM UTC every day
+        - cron: "0 8 * * *"
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v5
+            - name: Gets semantic release info
+              id: semantic_release_info
+              uses: jossef/action-semantic-release-info@v3.0.0
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+            - name: Update Version and Commit
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              run: |
+                  echo "Version: ${{steps.semantic_release_info.outputs.version}}"
+                  sed -E -i "s/^(version[[:space:]]*=[[:space:]]*)\"[^\"]+\"/\1\"${{steps.semantic_release_info.outputs.version}}\"/" pyproject.toml
+                  git config --local user.email "action@github.com"
+                  git config --local user.name "GitHub Action"
+                  git add -A
+                  git commit -m "chore: bumping version to ${{steps.semantic_release_info.outputs.version}}"
+                  git tag ${{ steps.semantic_release_info.outputs.git_tag }}
+            - name: Push changes
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: ad-m/github-push-action@v1.0.0
+              with:
+                  github_token: ${{ github.token }}
+                  tags: true
+            - name: Create GitHub Release
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              with:
+                  tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+                  release_name: ${{ steps.semantic_release_info.outputs.git_tag }}
+                  body: ${{ steps.semantic_release_info.outputs.notes }}
+                  draft: false
+                  prerelease: false
+            - name: Install dependencies
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install build
+            - name: Build package
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              run: python -m build
+            - name: Publish package to PyPi Test
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+              with:
+                  user: __token__
+                  password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+                  repository_url: https://test.pypi.org/legacy/
+                  verbose: true
+            - name: Publish package to PyPi Live
+              if: ${{steps.semantic_release_info.outputs.version != ''}}
+              uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
+              with:
+                  user: __token__
+                  password: ${{ secrets.PYPI_API_TOKEN }}
+                  verbose: true


### PR DESCRIPTION
I have recreated the auto release PR after my accidental deletion.  This triggers based on contents in master.    It will auto increment the .toml file to the new version and upload to pypi.  Creating a release in github with release notes to match.  It does require tokens be added to the repo for pypi before this will work. 

I have set it to run on commit as that appears to be how you currently work.  

I personally like to just do PRs directly to master with squash of commits.  Then have the release set to the schedule of my liking for frequency, say once a week.  As no one really pulls from master except devs. I find the dev branch in another spot just adds another step.  

Frequency of release could be reduced to say weekly so all fixes, features etc all get bundled into a single release once a week.  Just my 2 cents though.   No need for that now. 

