### PR TITLE
fix: deviceContainer global variable

### DIFF
--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -19,7 +19,7 @@ from pyvesync.const import (
     REGION_API_MAP,
     STATUS_OK,
 )
-from pyvesync.device_container import DeviceContainer, DeviceContainerInstance
+from pyvesync.device_container import DeviceContainer
 from pyvesync.models.vesync_models import (
     FirmwareDeviceItemModel,
     RequestDeviceListModel,

--- a/src/pyvesync/vesync.py
+++ b/src/pyvesync/vesync.py
@@ -138,7 +138,7 @@ class VeSync:  # pylint: disable=function-redefined
         self.language: str = 'en'
         self.enabled = False
         self.in_process = False
-        self._device_container: DeviceContainer = DeviceContainerInstance
+        self._device_container: DeviceContainer = DeviceContainer()
 
         # Initialize authentication manager
         self._auth = VeSyncAuth(


### PR DESCRIPTION
Device container was shared by all instances of pyvesync.   Garbage collection also isn't used when this is done.  That is my understanding.  So memory was being shared with a new instance of vesync. 