### PR TITLE
fix: email on each login

### DIFF
--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -60,7 +60,7 @@ MOBILE_ID = str(randint(1000000000000000, 9999999999999999))  # noqa: S311
 USER_TYPE = '1'
 BYPASS_APP_V = f'VeSync {APP_VERSION}'
 BYPASS_HEADER_UA = 'okhttp/3.12.1'
-TERMINAL_ID = '2' + str(uuid4()).replace('-', '')
+TERMINAL_ID = '2' + (__import__('uuid').uuid5(__import__('uuid').NAMESPACE_DNS, f"{__import__('uuid').getnode():x}-{__import__('platform').node() or ''}").hex)
 CLIENT_TYPE = 'vesyncApp'
 
 STATUS_OK = 200

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -30,6 +30,8 @@ import string
 from enum import Enum, IntEnum, StrEnum
 from random import choices, randint
 from types import MappingProxyType
+import platform
+import uuid
 
 from pyvesync.utils.enum_utils import IntEnumMixin
 
@@ -59,14 +61,8 @@ MOBILE_ID = str(randint(1000000000000000, 9999999999999999))  # noqa: S311
 USER_TYPE = '1'
 BYPASS_APP_V = f'VeSync {APP_VERSION}'
 BYPASS_HEADER_UA = 'okhttp/3.12.1'
-TERMINAL_ID = '2' + (
-    __import__('uuid')
-    .uuid5(
-        __import__('uuid').NAMESPACE_DNS,
-        f'{__import__("uuid").getnode():x}-{__import__("platform").node() or ""}',
-    )
-    .hex
-)
+TERMINAL_ID = '2' + (uuid.uuid5(uuid.NAMESPACE_DNS, f"{uuid.getnode():x}-{platform.node() or ''}").hex)
+
 CLIENT_TYPE = 'vesyncApp'
 
 STATUS_OK = 200

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -26,12 +26,12 @@ Attributes:
 
 from __future__ import annotations
 
+import platform
 import string
+import uuid
 from enum import Enum, IntEnum, StrEnum
 from random import choices, randint
 from types import MappingProxyType
-import platform
-import uuid
 
 from pyvesync.utils.enum_utils import IntEnumMixin
 
@@ -61,7 +61,9 @@ MOBILE_ID = str(randint(1000000000000000, 9999999999999999))  # noqa: S311
 USER_TYPE = '1'
 BYPASS_APP_V = f'VeSync {APP_VERSION}'
 BYPASS_HEADER_UA = 'okhttp/3.12.1'
-TERMINAL_ID = '2' + (uuid.uuid5(uuid.NAMESPACE_DNS, f"{uuid.getnode():x}-{platform.node() or ''}").hex)
+TERMINAL_ID = '2' + (
+    uuid.uuid5(uuid.NAMESPACE_DNS, f'{uuid.getnode():x}-{platform.node() or ""}').hex
+)
 
 CLIENT_TYPE = 'vesyncApp'
 

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -30,7 +30,6 @@ import string
 from enum import Enum, IntEnum, StrEnum
 from random import choices, randint
 from types import MappingProxyType
-from uuid import uuid4
 
 from pyvesync.utils.enum_utils import IntEnumMixin
 
@@ -60,7 +59,14 @@ MOBILE_ID = str(randint(1000000000000000, 9999999999999999))  # noqa: S311
 USER_TYPE = '1'
 BYPASS_APP_V = f'VeSync {APP_VERSION}'
 BYPASS_HEADER_UA = 'okhttp/3.12.1'
-TERMINAL_ID = '2' + (__import__('uuid').uuid5(__import__('uuid').NAMESPACE_DNS, f"{__import__('uuid').getnode():x}-{__import__('platform').node() or ''}").hex)
+TERMINAL_ID = '2' + (
+    __import__('uuid')
+    .uuid5(
+        __import__('uuid').NAMESPACE_DNS,
+        f'{__import__("uuid").getnode():x}-{__import__("platform").node() or ""}',
+    )
+    .hex
+)
 CLIENT_TYPE = 'vesyncApp'
 
 STATUS_OK = 200


### PR DESCRIPTION
vesync told a user on the HA form that the reason they email on each login is because our terminal ID changes.  This solves that and uses machine specific seed data. This means it doesn't change on each run but is still unique to the device. 

https://github.com/home-assistant/core/issues/155013