### PR TITLE
fix: 6000s two auto modes

### DIFF
--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -721,7 +721,6 @@ humidifier_modules = [
             HumidifierModes.SLEEP: 'sleep',
             HumidifierModes.HUMIDITY: 'humidity',
             HumidifierModes.MANUAL: 'manual',
-            HumidifierModes.AUTOPRO: 'autoPro',
         },
         mist_levels=list(range(1, 10)),
         device_alias='Superior 6000S',


### PR DESCRIPTION
The 6000s only has one auto mode. Manual calls it Auto not autopro so using that here. 