### PR TITLE
fix: allow str in DeviceStatus.from_bool

### DIFF
--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -250,8 +250,10 @@ class DeviceStatus(StrEnum):
         return cls.UNKNOWN
 
     @classmethod
-    def from_bool(cls, value: bool) -> DeviceStatus:
+    def from_bool(cls, value: bool|str) -> DeviceStatus:
         """Convert boolean value to corresponding string."""
+        if isinstance(value, str):
+            return cls.from_bool_string(value)
         return cls.ON if value is True else cls.OFF
     
     @classmethod

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -250,16 +250,16 @@ class DeviceStatus(StrEnum):
         return cls.UNKNOWN
 
     @classmethod
-    def from_bool(cls, value: bool|str) -> DeviceStatus:
+    def from_bool(cls, value: bool | str) -> DeviceStatus:
         """Convert boolean value to corresponding string."""
         if isinstance(value, str):
             return cls.from_bool_string(value)
         return cls.ON if value is True else cls.OFF
-    
+
     @classmethod
     def from_bool_string(cls, value: str) -> DeviceStatus:
         """Convert boolean value to corresponding string."""
-        return cls.ON if value == "true" else cls.OFF
+        return cls.ON if value == 'true' else cls.OFF
 
 
 class ConnectionStatus(StrEnum):

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -253,6 +253,11 @@ class DeviceStatus(StrEnum):
     def from_bool(cls, value: bool) -> DeviceStatus:
         """Convert boolean value to corresponding string."""
         return cls.ON if value is True else cls.OFF
+    
+    @classmethod
+    def from_bool_string(cls, value: str) -> DeviceStatus:
+        """Convert boolean value to corresponding string."""
+        return cls.ON if value == "true" else cls.OFF
 
 
 class ConnectionStatus(StrEnum):

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -721,7 +721,6 @@ humidifier_modules = [
             HumidifierModes.SLEEP: 'sleep',
             HumidifierModes.HUMIDITY: 'humidity',
             HumidifierModes.MANUAL: 'manual',
-            HumidifierModes.AUTOPRO: 'autoPro',
         },
         mist_levels=list(range(1, 10)),
         device_alias='Superior 6000S',


### PR DESCRIPTION
The 300s humidifer and assume others report the screen as always on as currently it checks if the value is present, not what it states. 