### PR TITLE
fix: 6000s fix temperature decimal place

### DIFF
--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -43,7 +43,7 @@ class HumidifierState(DeviceState):
         mode (str): Current mode.
         nightlight_brightness (int): Nightlight brightness level.
         nightlight_status (str): Nightlight status.
-        temperature (int): Current temperature.
+        temperature (float): Current temperature.
         warm_mist_enabled (bool): Warm mist enabled status.
         warm_mist_level (int): Warm mist level.
         water_lacks (bool): Water lacks status.
@@ -108,7 +108,7 @@ class HumidifierState(DeviceState):
         self.warm_mist_level: int | None = None
         self.water_lacks: bool = False
         self.water_tank_lifted: bool = False
-        self.temperature: int | None = None
+        self.temperature: float | None = None #Fahrenheit
         # Superior 6000S States
         self.auto_preference: int | None = None
         self.filter_life_percent: int | None = None

--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -108,7 +108,7 @@ class HumidifierState(DeviceState):
         self.warm_mist_level: int | None = None
         self.water_lacks: bool = False
         self.water_tank_lifted: bool = False
-        self.temperature: float | None = None #Fahrenheit
+        self.temperature: float | None = None  # Fahrenheit
         # Superior 6000S States
         self.auto_preference: int | None = None
         self.filter_life_percent: int | None = None

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -464,7 +464,9 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.display_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.auto_preference = resp_model.autoPreference
         self.state.filter_life_percent = resp_model.filterLifePercent
-        self.state.temperature = resp_model.temperature/1000  # Fahrenheit but without decimals
+        self.state.temperature = (
+            resp_model.temperature / 1000
+        )  # Fahrenheit but without decimals
 
         drying_mode = resp_model.dryingMode
         if drying_mode is not None:

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -464,7 +464,7 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.display_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.auto_preference = resp_model.autoPreference
         self.state.filter_life_percent = resp_model.filterLifePercent
-        self.state.temperature = resp_model.temperature  # Unknown units
+        self.state.temperature = resp_model.temperature/1000  # Fahrenheit but without decimals
 
         drying_mode = resp_model.dryingMode
         if drying_mode is not None:

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -464,7 +464,7 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.display_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.auto_preference = resp_model.autoPreference
         self.state.filter_life_percent = resp_model.filterLifePercent
-        self.state.temperature = resp_model.temperature/1000  # Fahrenheit but without decimals
+        self.state.temperature = resp_model.temperature/10  # Fahrenheit but without decimals
 
         drying_mode = resp_model.dryingMode
         if drying_mode is not None:

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -464,7 +464,9 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.display_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.auto_preference = resp_model.autoPreference
         self.state.filter_life_percent = resp_model.filterLifePercent
-        self.state.temperature = resp_model.temperature/10  # Fahrenheit but without decimals
+        self.state.temperature = (
+            resp_model.temperature / 10
+        )  # Fahrenheit but without decimals
 
         drying_mode = resp_model.dryingMode
         if drying_mode is not None:


### PR DESCRIPTION
6000s responses come in like the following.   Decimal needs to be shifted to accurately show F. 


```

Response Headers: 
 {
  "Date": "Fri, 31 Oct 2025 01:00:35 GMT",
  "Content-Type": "application/json;charset=UTF-8",
  "Transfer-Encoding": "chunked",
  "Connection": "keep-alive",
  "Content-Encoding": "gzip"
}
Response Body: 
 {
  "traceId": "1761872434",
  "code": 0,
  "msg": "request success",
  "module": null,
  "stacktrace": null,
  "result": {
    "traceId": "1761872434",
    "code": 0,
    "result": {
      "powerSwitch": 0,
      "humidity": 35,
      "targetHumidity": 40,
      "virtualLevel": 9,
      "mistLevel": 3,
      "workMode": "humidity",
      "waterLacksState": 0,
      "waterTankLifted": 0,
      "autoStopSwitch": 1,
      "autoStopState": 0,
      "screenSwitch": 0,
      "screenState": 0,
      "scheduleCount": 0,
      "timerRemain": 0,
      "errorCode": 0,
      "autoPreference": 1,
      "childLockSwitch": 1,
      "filterLifePercent": 77,
      "temperature": 629,
      "maxLevelNotify": 0,
      "waterShortageDryingSwitch": 1,
      "humidityPreference": 1,
      "dryingMode": {
        "dryingLevel": 1,
        "autoDryingSwitch": 1,
        "dryingState": 0,
        "dryingRemain": 0
      },
      "isSupportSensor": 1,
      "sensorContent": {
        "sensorStatus": "noDevices"
      },
      "waterPump": {
        "cleanStatus": 0,
        "remainTime": 0,
        "totalTime": 65
      },
      "lastDryingCompletedTime": 1761850797,
      "afterDryLastHumidityTime": 1761797100
    }
  }
}
```