### PR TITLE
fix: remove 131 child lock

### DIFF
--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -871,7 +871,6 @@ class VeSyncAir131(BypassV1Mixin, VeSyncPurifier):
             self.state.filter_life = details.filterLife.percent
         self.state.display_status = DeviceStatus(details.screenStatus)
         self.state.display_set_status = details.screenStatus
-        self.state.child_lock = bool(DeviceStatus(details.childLock))
         self.state.mode = details.mode
         self.state.fan_level = details.level or 0
         self.state.fan_set_level = details.level or 0

--- a/src/pyvesync/models/purifier_models.py
+++ b/src/pyvesync/models/purifier_models.py
@@ -246,7 +246,6 @@ class Purifier131Result(BypassV1Result):
     mode: str
     airQuality: str
     deviceName: str
-    childLock: str
     deviceStatus: str
     connectionStatus: str
     filterLife: Purifier131Filter | None = None


### PR DESCRIPTION
The 131 child lock doesn't exist on this model.  The API does however always report it off. It can't be toggled via this API or native app.  Removing keeps HA clean. 