### PR TITLE
fix: 6000s screen state

### DIFF
--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -460,7 +460,7 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.water_tank_lifted = bool(resp_model.waterTankLifted)
         self.state.automatic_stop_config = bool(resp_model.autoStopSwitch)
         self.state.auto_stop_target_reached = bool(resp_model.autoStopState)
-        self.state.display_set_status = DeviceStatus.from_int(resp_model.screenSwitch)
+        self.state.display_set_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.display_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.auto_preference = resp_model.autoPreference
         self.state.filter_life_percent = resp_model.filterLifePercent


### PR DESCRIPTION
Two values exist in the API data screenState and screenSwitch.   

I am not totally clear what screenSwitch is, since it does change.  However screen state is what is tied to showing screen on or off in the native app.  They don't always line up. 