### PR TITLE
fix: align 6000s filter life names to purifiers

### DIFF
--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -61,7 +61,7 @@ class HumidifierState(DeviceState):
         'drying_mode_level',
         'drying_mode_status',
         'drying_mode_time_remain',
-        'filter_life_percent',
+        'filter_life',
         'humidity',
         'humidity_high',
         'mist_level',
@@ -111,7 +111,7 @@ class HumidifierState(DeviceState):
         self.temperature: int | None = None
         # Superior 6000S States
         self.auto_preference: int | None = None
-        self.filter_life_percent: int | None = None
+        self.filter_life: int | None = None
         self.drying_mode_level: int | None = None
         self.drying_mode_auto_switch: str | None = None
         self.drying_mode_status: str | None = None

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -463,7 +463,7 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.display_set_status = DeviceStatus.from_int(resp_model.screenSwitch)
         self.state.display_status = DeviceStatus.from_int(resp_model.screenState)
         self.state.auto_preference = resp_model.autoPreference
-        self.state.filter_life_percent = resp_model.filterLifePercent
+        self.state.filter_life = resp_model.filterLifePercent
         self.state.temperature = resp_model.temperature  # Unknown units
 
         drying_mode = resp_model.dryingMode


### PR DESCRIPTION
Right now purifiers name and 6000s filter name is different even though both are percentage.  This means I would need duplicate code to offer this sensor in HA. Aligning will offer users the filter life automatically in HA with current logic. 