### PR TITLE
chore: update semantic title version

### DIFF
--- a/.github/workflows/PRTitle.yaml
+++ b/.github/workflows/PRTitle.yaml
@@ -10,7 +10,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Trying to fix the fact it is failing here: https://github.com/webdjoe/pyvesync/pull/387  It shouldn't and doesn't on my Hyundai repo with a newer version.