### PR TITLE
fix: 6000s Map Auto to AutoPro

### DIFF
--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -360,8 +360,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         """
         if HumidifierModes.AUTO in self.mist_modes:
             return await self.set_mode(HumidifierModes.AUTO)
-        logger.debug('Auto mode not supported for this device.')
-        return await self.set_mode(HumidifierModes.AUTO)
+        logger.error('Auto mode not supported for this device.')
 
     async def set_manual_mode(self) -> bool:
         """Set Humidifier to Manual Mode.
@@ -371,8 +370,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         """
         if HumidifierModes.MANUAL in self.mist_modes:
             return await self.set_mode(HumidifierModes.MANUAL)
-        logger.debug('Manual mode not supported for this device.')
-        return await self.set_mode(HumidifierModes.MANUAL)
+        logger.error('Manual mode not supported for this device.')
 
     async def set_sleep_mode(self) -> bool:
         """Set Humidifier to Sleep Mode.
@@ -382,8 +380,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         """
         if HumidifierModes.SLEEP in self.mist_modes:
             return await self.set_mode(HumidifierModes.SLEEP)
-        logger.debug('Sleep mode not supported for this device.')
-        return await self.set_mode(HumidifierModes.SLEEP)
+        logger.error('Sleep mode not supported for this device.')
 
     async def set_humidity(self, humidity: int) -> bool:
         """Set Humidifier Target Humidity.
@@ -395,7 +392,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
             bool: Success of request.
         """
         del humidity
-        logger.debug('Target humidity is not supported or configured for this device.')
+        logger.error('Target humidity is not supported or configured for this device.')
         return False
 
     async def set_nightlight_brightness(self, brightness: int) -> bool:
@@ -409,9 +406,9 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         """
         del brightness
         if not self.supports_nightlight_brightness:
-            logger.debug('Nightlight brightness is not supported for this device.')
+            logger.error('Nightlight brightness is not supported for this device.')
             return False
-        logger.debug('Nightlight brightness has not been configured.')
+        logger.error('Nightlight brightness has not been configured.')
         return False
 
     async def set_warm_level(self, warm_level: int) -> bool:
@@ -425,16 +422,16 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         """
         del warm_level
         if self.supports_warm_mist:
-            logger.debug('Warm level has not been configured.')
+            logger.error('Warm level has not been configured.')
             return False
-        logger.debug('Warm level is not supported for this device.')
+        logger.error('Warm level is not supported for this device.')
         return False
 
     async def toggle_drying_mode(self, toggle: bool | None = None) -> bool:
         """enable/disable drying filters after turning off."""
         del toggle
         if self.supports_drying_mode:
-            logger.debug('Drying mode is not configured for this device.')
+            logger.error('Drying mode is not configured for this device.')
             return False
-        logger.debug('Drying mode is not supported for this device.')
+        logger.error('Drying mode is not supported for this device.')
         return False

--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -438,3 +438,11 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
             return False
         logger.error('Drying mode is not supported for this device.')
         return False
+
+    async def turn_on_drying_mode(self) -> bool:
+        """Turn on drying mode."""
+        return await self.toggle_drying_mode(True)
+
+    async def turn_off_drying_mode(self) -> bool:
+        """Turn off drying mode."""
+        return await self.toggle_drying_mode(False)

--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -361,6 +361,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         if HumidifierModes.AUTO in self.mist_modes:
             return await self.set_mode(HumidifierModes.AUTO)
         logger.error('Auto mode not supported for this device.')
+        return False
 
     async def set_manual_mode(self) -> bool:
         """Set Humidifier to Manual Mode.
@@ -371,6 +372,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         if HumidifierModes.MANUAL in self.mist_modes:
             return await self.set_mode(HumidifierModes.MANUAL)
         logger.error('Manual mode not supported for this device.')
+        return False
 
     async def set_sleep_mode(self) -> bool:
         """Set Humidifier to Sleep Mode.
@@ -381,6 +383,7 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         if HumidifierModes.SLEEP in self.mist_modes:
             return await self.set_mode(HumidifierModes.SLEEP)
         logger.error('Sleep mode not supported for this device.')
+        return False
 
     async def set_humidity(self, humidity: int) -> bool:
         """Set Humidifier Target Humidity.

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -645,7 +645,6 @@ class HumidifierModes(Features):
     TURBO = 'turbo'
     PET = 'pet'
     UNKNOWN = 'unknown'
-    AUTOPRO = 'autoPro'
 
 
 class FanModes(StrEnum):

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -645,7 +645,7 @@ class HumidifierModes(Features):
     TURBO = 'turbo'
     PET = 'pet'
     UNKNOWN = 'unknown'
-    AUTOPRO = 'autopro'
+    AUTOPRO = 'autoPro'
 
 
 class FanModes(StrEnum):

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -861,3 +861,25 @@ ENERGY_HISTORY_OFFSET_WHOGPLUG = {
     EnergyIntervals.WEEK: 500000,
     EnergyIntervals.MONTH: 2500000,
 }
+
+# ------------------- HUMIDIFIER CONST ------------------ #
+
+
+class DryingModes(StrEnum):
+    """Drying modes for VeSync humidifiers.
+
+    Attributes:
+        ON: Drying mode is on.
+        OFF: Drying mode is off.
+    """
+
+    DONE = 'done'
+    RUNNING = 'on'
+    PAUSE = 'pause'
+
+
+DRYING_MODES: dict[str, int] = {
+    DryingModes.DONE: 0,
+    DryingModes.RUNNING: 1,
+    DryingModes.PAUSE: 2,
+}

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -733,7 +733,7 @@ humidifier_modules = [
         dev_types=['LEH-S601S-WUS', 'LEH-S601S-WUSR', 'LEH-S601S-WEUR'],
         features=[HumidifierFeatures.DRYING_MODE],
         mist_modes={
-            HumidifierModes.AUTO: 'autoPro',
+            HumidifierModes.AUTO: 'auto',
             HumidifierModes.SLEEP: 'sleep',
             HumidifierModes.HUMIDITY: 'humidity',
             HumidifierModes.MANUAL: 'manual',

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -733,7 +733,7 @@ humidifier_modules = [
         dev_types=['LEH-S601S-WUS', 'LEH-S601S-WUSR', 'LEH-S601S-WEUR'],
         features=[HumidifierFeatures.DRYING_MODE],
         mist_modes={
-            HumidifierModes.AUTO: 'auto',
+            HumidifierModes.AUTO: 'autoPro',
             HumidifierModes.SLEEP: 'sleep',
             HumidifierModes.HUMIDITY: 'humidity',
             HumidifierModes.MANUAL: 'manual',

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -835,4 +835,4 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
         if HumidifierModes.AUTO in self.mist_modes:
             return await self.set_mode(HumidifierModes.AUTOPRO)
         logger.debug('Auto mode not supported for this device.')
-        return await self.set_mode(HumidifierModes.AUTO)
+        return False

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -452,7 +452,10 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         """Set state from Superior 6000S API result model."""
         self.state.device_status = DeviceStatus.from_int(resp_model.powerSwitch)
         self.state.connection_status = ConnectionStatus.ONLINE
-        self.state.mode = resp_model.workMode
+        if resp_model.workMode == HumidifierModes.AUTOPRO:
+            self.state.mode = HumidifierModes.AUTO
+        else:
+            self.state.mode = resp_model.workMode
         self.state.auto_target_humidity = resp_model.targetHumidity
         self.state.humidity = resp_model.humidity
         self.state.mist_level = resp_model.mistLevel
@@ -669,10 +672,7 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
             return
         self.state.device_status = DeviceStatus.from_int(resp_model.powerSwitch)
         self.state.connection_status = ConnectionStatus.ONLINE
-        if resp_model.workMode == HumidifierModes.AUTOPRO:
-            self.state.mode = HumidifierModes.AUTO
-        else:
-            self.state.mode = resp_model.workMode
+        self.state.mode = resp_model.workMode
         self.state.humidity = resp_model.humidity
         self.state.auto_target_humidity = resp_model.targetHumidity
         self.state.mist_level = resp_model.mistLevel

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -452,9 +452,7 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         """Set state from Superior 6000S API result model."""
         self.state.device_status = DeviceStatus.from_int(resp_model.powerSwitch)
         self.state.connection_status = ConnectionStatus.ONLINE
-        self.state.mode = Helpers.get_key(
-            self.mist_modes, resp_model.workMode, None
-        )
+        self.state.mode = Helpers.get_key(self.mist_modes, resp_model.workMode, None)
         if self.state.mode is None:
             logger.warning('Unknown mist mode received: %s', resp_model.workMode)
 
@@ -475,7 +473,8 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         drying_mode = resp_model.dryingMode
         if drying_mode is not None:
             self.state.drying_mode_status = Helpers.get_key(
-                DRYING_MODES, drying_mode.dryingState, None)
+                DRYING_MODES, drying_mode.dryingState, None
+            )
             self.state.drying_mode_level = drying_mode.dryingLevel
             self.state.drying_mode_auto_switch = DeviceStatus.from_int(
                 drying_mode.autoDryingSwitch

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -9,7 +9,7 @@ import orjson
 from typing_extensions import deprecated
 
 from pyvesync.base_devices import VeSyncHumidifier
-from pyvesync.const import ConnectionStatus, DeviceStatus
+from pyvesync.const import ConnectionStatus, DeviceStatus, HumidifierModes
 from pyvesync.models.bypass_models import ResultV2GetTimer, ResultV2SetTimer
 from pyvesync.models.humidifier_models import (
     ClassicLVHumidResult,
@@ -813,3 +813,16 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
         self.state.automatic_stop_config = toggle
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
+    
+    # Override so that auto mode sets to autoPro
+
+    async def set_auto_mode(self) -> bool:
+        """Set Humidifier to Auto Mode.
+
+        Returns:
+            bool: Success of request.
+        """
+        if HumidifierModes.AUTO in self.mist_modes:
+            return await self.set_mode(HumidifierModes.AUTOPRO)
+        logger.debug('Auto mode not supported for this device.')
+        return await self.set_mode(HumidifierModes.AUTO)

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -665,7 +665,10 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
             return
         self.state.device_status = DeviceStatus.from_int(resp_model.powerSwitch)
         self.state.connection_status = ConnectionStatus.ONLINE
-        self.state.mode = resp_model.workMode
+        if resp_model.workMode == HumidifierModes.AUTOPRO:
+            self.state.mode = HumidifierModes.AUTO
+        else:
+            self.state.mode = resp_model.workMode
         self.state.humidity = resp_model.humidity
         self.state.auto_target_humidity = resp_model.targetHumidity
         self.state.mist_level = resp_model.mistLevel

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -597,7 +597,7 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         r = Helpers.process_dev_response(logger, 'set_humidity_mode', self, r_dict)
         if r is None:
             return False
-        if mode is HumidifierModes.AUTOPRO:
+        if mode == HumidifierModes.AUTOPRO:
             mode = HumidifierModes.AUTO
         self.state.mode = mode
         self.state.device_status = DeviceStatus.ON

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -623,6 +623,19 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
+    # Override so that auto mode sets to autoPro
+
+    async def set_auto_mode(self) -> bool:
+        """Set Humidifier to Auto Mode.
+
+        Returns:
+            bool: Success of request.
+        """
+        if HumidifierModes.AUTO in self.mist_modes:
+            return await self.set_mode(HumidifierModes.AUTOPRO)
+        logger.debug('Auto mode not supported for this device.')
+        return False
+
 
 class VeSyncHumid1000S(VeSyncHumid200300S):
     """Levoit OasisMist 1000S Specific class.
@@ -823,16 +836,3 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
         self.state.automatic_stop_config = toggle
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
-
-    # Override so that auto mode sets to autoPro
-
-    async def set_auto_mode(self) -> bool:
-        """Set Humidifier to Auto Mode.
-
-        Returns:
-            bool: Success of request.
-        """
-        if HumidifierModes.AUTO in self.mist_modes:
-            return await self.set_mode(HumidifierModes.AUTOPRO)
-        logger.debug('Auto mode not supported for this device.')
-        return False

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -9,7 +9,7 @@ import orjson
 from typing_extensions import deprecated
 
 from pyvesync.base_devices import VeSyncHumidifier
-from pyvesync.const import ConnectionStatus, DeviceStatus
+from pyvesync.const import DRYING_MODES, ConnectionStatus, DeviceStatus
 from pyvesync.models.bypass_models import ResultV2GetTimer, ResultV2SetTimer
 from pyvesync.models.humidifier_models import (
     ClassicLVHumidResult,
@@ -453,8 +453,10 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.device_status = DeviceStatus.from_int(resp_model.powerSwitch)
         self.state.connection_status = ConnectionStatus.ONLINE
         self.state.mode = Helpers.get_key(
-            self.mist_modes, resp_model.workMode, resp_model.workMode
+            self.mist_modes, resp_model.workMode, None
         )
+        if self.state.mode is None:
+            logger.warning('Unknown mist mode received: %s', resp_model.workMode)
 
         self.state.auto_target_humidity = resp_model.targetHumidity
         self.state.humidity = resp_model.humidity
@@ -472,7 +474,8 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
 
         drying_mode = resp_model.dryingMode
         if drying_mode is not None:
-            self.state.drying_mode_status = DeviceStatus.from_int(drying_mode.dryingState)
+            self.state.drying_mode_status = Helpers.get_key(
+                DRYING_MODES, drying_mode.dryingState, None)
             self.state.drying_mode_level = drying_mode.dryingLevel
             self.state.drying_mode_auto_switch = DeviceStatus.from_int(
                 drying_mode.autoDryingSwitch
@@ -522,32 +525,19 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
-    @deprecated('Use toggle_drying_mode() instead.')
-    async def set_drying_mode_enabled(self, mode: bool) -> bool:
-        """Set drying mode on/off."""
-        return await self.toggle_drying_mode(mode)
-
     async def toggle_drying_mode(self, toggle: bool | None = None) -> bool:
         if toggle is None:
             toggle = self.state.drying_mode_status != DeviceStatus.ON
 
         payload_data = {'autoDryingSwitch': int(toggle)}
         r_dict = await self.call_bypassv2_api('setDryingMode', payload_data)
-        r = Helpers.process_dev_response(logger, 'set_drying_mode_enabled', self, r_dict)
+        r = Helpers.process_dev_response(logger, 'toggle_drying_mode', self, r_dict)
         if r is None:
             return False
 
         self.state.connection_status = ConnectionStatus.ONLINE
         self.state.drying_mode_auto_switch = DeviceStatus.from_bool(toggle)
         return True
-
-    @deprecated('Use toggle_display() instead.')
-    async def set_display_enabled(self, mode: bool) -> bool:
-        """Set display on/off.
-
-        Deprecated method, please use toggle_display() instead.
-        """
-        return await self.toggle_display(mode)
 
     async def toggle_display(self, toggle: bool | None = None) -> bool:
         if toggle is None:
@@ -577,11 +567,6 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         self.state.auto_target_humidity = humidity
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
-
-    @deprecated('Use set_mode(mode: str) instead.')
-    async def set_humidity_mode(self, mode: str) -> bool:
-        """Set humidifier mode."""
-        return await self.set_mode(mode)
 
     async def set_mode(self, mode: str) -> bool:
         if mode.lower() not in self.mist_modes:

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -295,6 +295,7 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
             return False
 
         self.state.mode = mode
+        self.state.device_status = DeviceStatus.ON
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
@@ -596,7 +597,10 @@ class VeSyncSuperior6000S(BypassV2Mixin, VeSyncHumidifier):
         r = Helpers.process_dev_response(logger, 'set_humidity_mode', self, r_dict)
         if r is None:
             return False
+        if mode is HumidifierModes.AUTOPRO:
+            mode = HumidifierModes.AUTO
         self.state.mode = mode
+        self.state.device_status = DeviceStatus.ON
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
@@ -747,6 +751,8 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
             return False
 
         self.state.mode = mode
+
+        self.state.device_status = DeviceStatus.ON
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
@@ -763,6 +769,7 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
 
         self.state.mist_level = level
         self.state.mist_virtual_level = level
+        self.state.device_status = DeviceStatus.ON
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
 
@@ -828,4 +835,3 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
         if HumidifierModes.AUTO in self.mist_modes:
             return await self.set_mode(HumidifierModes.AUTOPRO)
         logger.debug('Auto mode not supported for this device.')
-        return await self.set_mode(HumidifierModes.AUTO)

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -816,7 +816,7 @@ class VeSyncHumid1000S(VeSyncHumid200300S):
         self.state.automatic_stop_config = toggle
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
-    
+
     # Override so that auto mode sets to autoPro
 
     async def set_auto_mode(self) -> bool:

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -328,7 +328,10 @@ class VeSyncOutlet10A(BypassV1Mixin, VeSyncOutlet):
         toggle_str = DeviceStatus.ON if toggle else DeviceStatus.OFF
         update_dict = {'status': toggle_str.value}
         response = await self.call_bypassv1_api(
-            RequestBypassV1, update_dict=update_dict, method='deviceStatus', endpoint='deviceStatus'
+            RequestBypassV1,
+            update_dict=update_dict,
+            method='deviceStatus',
+            endpoint='deviceStatus',
         )
         r_dict = Helpers.process_dev_response(logger, 'toggle_switch', self, response)
         if r_dict is None:

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -326,9 +326,9 @@ class VeSyncOutlet10A(BypassV1Mixin, VeSyncOutlet):
         if toggle is None:
             toggle = self.state.device_status != DeviceStatus.ON
         toggle_str = DeviceStatus.ON if toggle else DeviceStatus.OFF
-
+        update_dict = {'status': toggle_str.value}
         response = await self.call_bypassv1_api(
-            RequestBypassV1, method='deviceStatus', endpoint='deviceStatus'
+            RequestBypassV1, update_dict=update_dict, method='deviceStatus', endpoint='deviceStatus'
         )
         r_dict = Helpers.process_dev_response(logger, 'toggle_switch', self, response)
         if r_dict is None:

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -27,6 +27,7 @@ from pyvesync.models.outlet_models import (
     Request15ADetails,
     Request15ANightlight,
     Request15AStatus,
+    RequestESW03Status,
     RequestOutdoorStatus,
     RequestWHOGYearlyEnergy,
     Response7AOutlet,
@@ -328,7 +329,7 @@ class VeSyncOutlet10A(BypassV1Mixin, VeSyncOutlet):
         toggle_str = DeviceStatus.ON if toggle else DeviceStatus.OFF
         update_dict = {'status': toggle_str.value}
         response = await self.call_bypassv1_api(
-            RequestBypassV1,
+            RequestESW03Status,
             update_dict=update_dict,
             method='deviceStatus',
             endpoint='deviceStatus',

--- a/src/pyvesync/models/outlet_models.py
+++ b/src/pyvesync/models/outlet_models.py
@@ -84,6 +84,13 @@ class Response10ADetails(DataClassORJSONMixin):
 
 
 @dataclass
+class RequestESW03Status(RequestBypassV1):
+    """Request model for Etekcity 10A outlet status."""
+
+    status: str
+
+
+@dataclass
 class ResponseESW03Details(BypassV1Result):
     """Response model for Etekcity 10A outlet details."""
 

--- a/src/pyvesync/utils/helpers.py
+++ b/src/pyvesync/utils/helpers.py
@@ -8,6 +8,7 @@ import re
 import time
 from collections.abc import Iterator
 from dataclasses import InitVar, dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from mashumaro.exceptions import InvalidFieldValue, MissingField, UnserializableField
@@ -36,6 +37,8 @@ if TYPE_CHECKING:
 
 T = TypeVar('T')
 T_MODEL = TypeVar('T_MODEL', bound=DataClassORJSONMixin)
+
+ST = TypeVar('ST', str, int)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -554,18 +557,20 @@ class Helpers:
         return return_code, return_msg
 
     @staticmethod
-    def get_key(data: dict[str, str], key: str, default: str | None = None) -> str | None:
+    def get_key(
+        data: dict[StrEnum | str, ST], value: ST, default: str | None = None
+    ) -> str | StrEnum | None:
         """Get key from dictionary ignoring case sensitivity.
 
         Args:
             data (dict[str, Any]): Dictionary to search.
-            key (str): Key to search for.
+            value (str): Value to search for.
             default (Any): Default value to return if key not found.
 
         Returns:
             Any: Value associated with the key, or None if not found.
         """
-        return next((v for k, v in data.items() if k.lower() == key.lower()), default)
+        return next((k for k, v in data.items() if v == value), default)
 
 
 @dataclass(repr=False)

--- a/src/pyvesync/utils/helpers.py
+++ b/src/pyvesync/utils/helpers.py
@@ -553,6 +553,20 @@ class Helpers:
                 return_msg = msg
         return return_code, return_msg
 
+    @staticmethod
+    def get_key(data: dict[str, str], key: str, default: str | None = None) -> str | None:
+        """Get key from dictionary ignoring case sensitivity.
+
+        Args:
+            data (dict[str, Any]): Dictionary to search.
+            key (str): Key to search for.
+            default (Any): Default value to return if key not found.
+
+        Returns:
+            Any: Value associated with the key, or None if not found.
+        """
+        return next((v for k, v in data.items() if k.lower() == key.lower()), default)
+
 
 @dataclass(repr=False)
 class Timer:

--- a/src/tests/api/vesynchumidifier/LEH-S601S.yaml
+++ b/src/tests/api/vesynchumidifier/LEH-S601S.yaml
@@ -190,6 +190,33 @@ turn_off_display:
     userCountryCode: US
   method: post
   url: /cloud/v2/deviceManaged/bypassV2
+turn_off_drying_mode:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: LEH-S601S-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LEH-S601S-CID
+    method: bypassV2
+    payload:
+      data:
+        autoDryingSwitch: 0
+      method: setDryingMode
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
 turn_on:
   headers:
     Content-Type: application/json; charset=UTF-8

--- a/src/tests/api/vesynchumidifier/LUH-A602S-WUS.yaml
+++ b/src/tests/api/vesynchumidifier/LUH-A602S-WUS.yaml
@@ -108,6 +108,35 @@ set_mist_level:
     userCountryCode: US
   method: post
   url: /cloud/v2/deviceManaged/bypassV2
+set_warm_level:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: LUH-A602S-WUS-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LUH-A602S-WUS-CID
+    method: bypassV2
+    payload:
+      data:
+        id: 0
+        level: 3
+        type: warm
+      method: setVirtualLevel
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
 turn_off:
   headers:
     Content-Type: application/json; charset=UTF-8

--- a/src/tests/api/vesyncoutlet/ESO15-TB.yaml
+++ b/src/tests/api/vesyncoutlet/ESO15-TB.yaml
@@ -1,26 +1,3 @@
-update:
-  headers:
-    Content-Type: application/json; charset=UTF-8
-    User-Agent: okhttp/3.12.1
-  json_object:
-    acceptLanguage: en
-    accountID: sample_id
-    appVersion: 5.6.60
-    cid: ESO15-TB-CID
-    configModel: ConfigModule
-    configModule: ConfigModule
-    debugMode: false
-    deviceId: ESO15-TB-CID
-    method: deviceDetail
-    phoneBrand: pyvesync
-    phoneOS: Android
-    timeZone: America/New_York
-    token: sample_tk
-    traceId: TRACE_ID
-    userCountryCode: US
-    uuid: ESO15-TB-UUID
-  method: post
-  url: /cloud/v1/deviceManaged/deviceDetail
 get_monthly_energy:
   headers:
     Content-Type: application/json; charset=UTF-8
@@ -131,3 +108,26 @@ turn_on:
     uuid: ESO15-TB-UUID
   method: post
   url: /cloud/v1/deviceManaged/deviceStatus
+update:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: ESO15-TB-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: ESO15-TB-CID
+    method: deviceDetail
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+    uuid: ESO15-TB-UUID
+  method: post
+  url: /cloud/v1/deviceManaged/deviceDetail

--- a/src/tests/api/vesyncoutlet/ESW03.yaml
+++ b/src/tests/api/vesyncoutlet/ESW03.yaml
@@ -14,6 +14,7 @@ turn_off:
     method: deviceStatus
     phoneBrand: pyvesync
     phoneOS: Android
+    status: 'off'
     timeZone: America/New_York
     token: sample_tk
     traceId: TRACE_ID
@@ -37,6 +38,7 @@ turn_on:
     method: deviceStatus
     phoneBrand: pyvesync
     phoneOS: Android
+    status: 'on'
     timeZone: America/New_York
     token: sample_tk
     traceId: TRACE_ID

--- a/src/tests/api/vesyncoutlet/ESW15-USA.yaml
+++ b/src/tests/api/vesyncoutlet/ESW15-USA.yaml
@@ -1,26 +1,3 @@
-update:
-  headers:
-    Content-Type: application/json; charset=UTF-8
-    User-Agent: okhttp/3.12.1
-  json_object:
-    acceptLanguage: en
-    accountID: sample_id
-    appVersion: 5.6.60
-    cid: ESW15-USA-CID
-    configModel: ConfigModule
-    configModule: ConfigModule
-    debugMode: false
-    deviceId: ESW15-USA-CID
-    method: deviceDetail
-    phoneBrand: pyvesync
-    phoneOS: Android
-    timeZone: America/New_York
-    token: sample_tk
-    traceId: TRACE_ID
-    userCountryCode: US
-    uuid: ESW15-USA-UUID
-  method: post
-  url: /cloud/v1/deviceManaged/deviceDetail
 get_monthly_energy:
   headers:
     Content-Type: application/json; charset=UTF-8
@@ -177,3 +154,26 @@ turn_on_nightlight:
     uuid: ESW15-USA-UUID
   method: post
   url: /cloud/v1/deviceManaged/outletNightLightCtl
+update:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: ESW15-USA-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: ESW15-USA-CID
+    method: deviceDetail
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+    uuid: ESW15-USA-UUID
+  method: post
+  url: /cloud/v1/deviceManaged/deviceDetail

--- a/src/tests/api/vesyncoutlet/wifi-switch-1.3.yaml
+++ b/src/tests/api/vesyncoutlet/wifi-switch-1.3.yaml
@@ -1,12 +1,3 @@
-update:
-  headers:
-    Content-Type: application/json; charset=UTF-8
-    User-Agent: okhttp/3.12.1
-    accountid: sample_id
-    tk: sample_tk
-    tz: America/New_York
-  method: get
-  url: /v1/device/wifi-switch-1.3-CID/detail
 get_monthly_energy:
   headers:
     Content-Type: application/json; charset=UTF-8
@@ -87,3 +78,12 @@ turn_on:
     tz: America/New_York
   method: put
   url: /v1/wifi-switch-1.3/wifi-switch-1.3-CID/status/on
+update:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+    accountid: sample_id
+    tk: sample_tk
+    tz: America/New_York
+  method: get
+  url: /v1/device/wifi-switch-1.3-CID/detail

--- a/src/tests/call_json_humidifiers.py
+++ b/src/tests/call_json_humidifiers.py
@@ -34,25 +34,13 @@ METHOD_RESPONSES['DEVTYPE'].default_factory = lambda: {"code": 0, "msg": "succes
 """
 from typing import Any
 from copy import deepcopy
+
 from pyvesync.device_map import humidifier_modules
-from pyvesync.const import HumidifierModes, DeviceStatus, ConnectionStatus
+from pyvesync.const import DRYING_MODES, HumidifierModes, DeviceStatus, ConnectionStatus, DryingModes
 from defaults import TestDefaults, FunctionResponses, build_bypass_v2_response, FunctionResponsesV2
 
 HUMIDIFIERS = [m.setup_entry for m in humidifier_modules]
 HUMIDIFIERS_NUM = len(HUMIDIFIERS)
-# FANS = ['Core200S', 'Core300S', 'Core400S', 'Core600S', 'LV-PUR131S', 'LV600S',
-#         'Classic300S', 'Classic200S', 'Dual200S', 'LV600S']
-
-
-# def INNER_RESULT(inner: dict) -> dict:
-#     return {
-#         "traceId": Defaults.trace_id,
-#         "code": 0,
-#         "msg": "request success",
-#         "module": None,
-#         "stacktrace": None,
-#         "result": {"traceId": Defaults.trace_id, "code": 0, "result": inner},
-#     }
 
 
 class HumidifierDefaults:
@@ -60,6 +48,8 @@ class HumidifierDefaults:
     connection_status = ConnectionStatus.ONLINE
     humidifier_mode = HumidifierModes.MANUAL
     nightlight_status = DeviceStatus.ON
+    drying_state = DryingModes.RUNNING
+    drying_mode_switch = DeviceStatus.ON
     nightlight_brightness = 50
     humidity = 50
     target_humidity = 60
@@ -246,8 +236,8 @@ HUMIDIFIER_DETAILS: dict[str, Any] = {
         "errorCode": 0,
         "dryingMode": {
             "dryingLevel": 1,
-            "autoDryingSwitch": 1,
-            "dryingState": 2,
+            "autoDryingSwitch": int(HumidifierDefaults.drying_mode_switch),
+            "dryingState": DRYING_MODES[HumidifierDefaults.drying_state],
             "dryingRemain": 7200,
         },
         "autoPreference": 1,

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -117,8 +117,8 @@ class TestHumidifiers(TestBase):
         ["set_mist_level", {"level": 2}],
     ]
     device_methods = {
-        "LUH-A602S-WUSR": [["set_warm_level", {"warm_level": 3}]],
-        "LEH-S601S-WUS": [["set_drying_mode_enabled", {"mode": False}]],
+        "LUH-A602S-WUS": [["set_warm_level", {"warm_level": 3}]],
+        "LEH-S601S": [["turn_off_drying_mode"]],
     }
 
     def test_details(self, setup_entry, method):
@@ -173,6 +173,9 @@ class TestHumidifiers(TestBase):
                 fan_obj.state.nightlight_brightness
                 == call_json_humidifiers.HumidifierDefaults.nightlight_brightness
             )
+        if fan_obj.supports_drying_mode:
+            assert fan_obj.state.drying_mode_auto_switch == call_json_humidifiers.HumidifierDefaults.drying_mode_switch
+            assert fan_obj.state.drying_mode_state == call_json_humidifiers.HumidifierDefaults.drying_state
 
         # Parse mock_api args tuple from arg, kwargs to kwargs
         all_kwargs = parse_args(self.mock_api)
@@ -239,12 +242,29 @@ class TestHumidifiers(TestBase):
             fan_obj.state.device_status = const.DeviceStatus.OFF
         elif method[0] == "turn_off":
             fan_obj.state.device_status = const.DeviceStatus.ON
+        elif method[0] == "set_auto_mode":
+            fan_obj.state.mode = const.HumidifierModes.MANUAL
+        elif method[0] == "set_manual_mode":
+            fan_obj.state.mode = const.HumidifierModes.AUTO
 
         # Call method with kwargs if defined
         if method_kwargs:
             self.run_in_loop(method_call, **method_kwargs)
         else:
             self.run_in_loop(method_call)
+
+        if method[0] == "set_auto_mode":
+            assert fan_obj.state.mode == const.HumidifierModes.AUTO
+        elif method[0] == "set_manual_mode":
+            assert fan_obj.state.mode == const.HumidifierModes.MANUAL
+        elif method[0] == "set_humidity":
+            assert fan_obj.state.target_humidity == method_kwargs["humidity"]
+        elif method[0] == "set_mist_level":
+            assert fan_obj.state.mist_level == method_kwargs["level"]
+        elif method[0] == "set_warm_level":
+            assert fan_obj.state.warm_mist_level == method_kwargs["warm_level"]
+        elif method[0] == "turn_off_drying_mode":
+            assert fan_obj.state.drying_mode_auto_switch == const.DeviceStatus.OFF
 
         # Parse arguments from mock_api call into a dictionary
         all_kwargs = parse_args(self.mock_api)


### PR DESCRIPTION
Maps autoPro to Auto in both directions.   Essentially removing autoPro from users perspective since in native app it is Auto.    Also adjusted mode setting logic and elevated debug to error when erroneous set commands used. 