### PR TITLE
fix: fryer_status unused

### DIFF
--- a/src/pyvesync/devices/vesynckitchen.py
+++ b/src/pyvesync/devices/vesynckitchen.py
@@ -363,7 +363,6 @@ class VeSyncAirFryer158(VeSyncFryer):
 
     __slots__ = (
         'cook_temps',
-        'fryer_status',
         'last_update',
         'ready_start',
         'refresh_interval',


### PR DESCRIPTION
A slot is declared for fryer_status but not used.  This causes errors on my debug side. 