### PR TITLE
fix: Add LEH-S602S-WUS model alternate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyvesync"
-version = "3.4.0"
+version = "3.4.1"
 description = "pyvesync is a library to manage Etekcity Devices, Cosori Air Fryers, and Levoit Air Purifiers run on the VeSync app."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -750,7 +750,7 @@ humidifier_modules = [
     ),
     HumidifierMap(
         class_name='VeSyncSuperior6000S',
-        dev_types=['LEH-S601S-WUS', 'LEH-S601S-WUSR', 'LEH-S601S-WEUR'],
+        dev_types=['LEH-S601S-WUS', 'LEH-S601S-WUSR', 'LEH-S601S-WEUR', 'LEH-S602S-WUS'],
         features=[HumidifierFeatures.DRYING_MODE, HumidifierFeatures.AUTO_STOP],
         mist_modes={
             HumidifierModes.AUTO: 'autoPro',


### PR DESCRIPTION
Thank you for the lib allowing us to manage our levoit devices in home assistant !

The levoit 6000s I received in Canada wasn't working when using the test script as it wasn't matching current mapping list. I updated it and re-ran the test script and can now see the informations:

```
Caller: VeSyncSuperior6000S.call_bypassv2_api [devices.vesynchumidifier]
API CALL to endpoint: /cloud/v2/deviceManaged/bypassV2
Host: smartapi.vesync.com
Full URL: https://smartapi.vesync.com/cloud/v2/deviceManaged/bypassV2
Response Status: 200
Method: POST
---------------Request-----------------
Request Headers: 
 {
  "Content-Type": "application/json; charset=UTF-8",
  "User-Agent": "okhttp/3.12.1"
}
Request Body: 
 {
  "acceptLanguage": "en",
  "accountID": "##_REDACTED_##",
  "appVersion": "5.6.60",
  "cid": "##_REDACTED_##",
  "configModule": "VS_WFON_AHM_LEH-S602S-WUS_US",
  "debugMode": false,
  "method": "bypassV2",
  "phoneBrand": "pyvesync",
  "phoneOS": "Android",
  "traceId": "1767886110",
  "timeZone": "America/New_York",
  "token": "##_REDACTED_##",
  "userCountryCode": "CA",
  "deviceId": "vsaq2a123d34875ac14f97a24f06c8c3",
  "configModel": "VS_WFON_AHM_LEH-S602S-WUS_US",
  "payload": {
    "data": {},
    "method": "getHumidifierStatus",
    "source": "APP"
  }
}
---------------Response-----------------
Response Headers: 
 {
  "Date": "Thu, 08 Jan 2026 15:28:31 GMT",
  "Content-Type": "application/json;charset=UTF-8",
  "Transfer-Encoding": "chunked",
  "Connection": "keep-alive",
  "Content-Encoding": "gzip"
}
Response Body: 
 {
  "traceId": "1767886110",
  "code": 0,
  "msg": "request success",
  "module": null,
  "stacktrace": null,
  "result": {
    "traceId": "1767886110",
    "code": 0,
    "result": {
      "powerSwitch": 1,
      "humidity": 50,
      "targetHumidity": 50,
      "virtualLevel": 9,
      "mistLevel": 3,
      "workMode": "humidity",
      "waterLacksState": 0,
      "waterTankLifted": 0,
      "autoStopSwitch": 1,
      "autoStopState": 1,
      "screenSwitch": 1,
      "screenState": 1,
      "scheduleCount": 0,
      "timerRemain": 0,
      "errorCode": 0,
      "totalWorkTime": 57360,
      "autoPreference": 1,
      "childLockSwitch": 0,
      "filterLifePercent": 100,
      "temperature": 629,
      "maxLevelNotify": 0,
      "waterShortageDryingSwitch": 1,
      "humidityPreference": 1,
      "dryingMode": {
        "dryingLevel": 2,
        "autoDryingSwitch": 1,
        "dryingState": 2,
        "dryingRemain": 7200
      },
      "isSupportSensor": 1,
      "sensorContent": {
        "sensorStatus": "noDevices"
      },
      "lastDryingCompletedTime": 1767816954,
      "afterDryLastHumidityTime": 1767833536
    }
  }
}
2026-01-08 10:28:31 - DEBUG - pyvesync.devices.vesynchumidifier - Superior 6000S for LEH-S602S-WUS API from get_details returned code: 0, message: Success
Random await finished
Device list pulled successfully.
2026-01-08 10:28:32 - DEBUG - pyvesync.vesync - Closing session, exiting context manager
2026-01-08 10:28:32 - DEBUG - pyvesync.vesync - Closing session, exiting context manager
```