### PR TITLE
feat: Add RGB nightlight support for VeSyncHumid200300S (LUH-O451S-WEU)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docstest/*
 .mcp.json
 .vesync_auth
 **/CLAUDE.md
+/docs/superpowers

--- a/docs/development/utils/colors.md
+++ b/docs/development/utils/colors.md
@@ -1,6 +1,6 @@
 # Color Handlers
 
-The `pyvesync.utils.colors` module provides classes and functions for handling color conversions and representations. It includes the `Color` class, which serves as a base for color manipulation, and the `HSV` and `RGB` classes for specific color models. The module is designed for internal use within the library and is not intended for public use.
+The `pyvesync.utils.colors` module provides classes and functions for handling color conversions and representations. It includes the `Color` class, which serves as a base for color manipulation, and the `HSV` and `RGB` classes for specific color models. The `RGBNightlightColor` class provides the color helpers used by humidifiers with an RGB nightlight. The module is designed for internal use within the library and is not intended for public use.
 
 ## Color class
 
@@ -36,4 +36,24 @@ This is the primary class that holds the color data and provides methods for con
       filters:
       - "!Config"
       - "!__post_init__"
+      - "!__str__"
+
+## RGBNightlightColor class
+
+Color helpers for devices with an RGB nightlight, such as the OasisMist 4.5L
+(`LUH-O451S-WEU`) humidifier. The VeSync app drives the nightlight color from
+an 8-color gradient slider and sends brightness-adjusted RGB values (brightness
+applied via the HSV value component) rather than a raw color plus a separate
+brightness. This class encapsulates that geometry: mapping an arbitrary RGB
+color to the slider position (`colorSliderLocation`), applying brightness to a
+color, and recovering the full-brightness base color from a dimmed one.
+
+::: pyvesync.utils.colors.RGBNightlightColor
+    handler: python
+    options:
+      show_root_heading: true
+      show_source: true
+      filters:
+      - "!Config"
+      - "!^__init*"
       - "!__str__"

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -83,15 +83,21 @@ Switches have minimal features, the dimmer switch is the only switch that has ad
 
 ### Humidifiers
 
-| Device Name | Night Light | Warm Mist |
-| ------ |-------------| ----- |
-| Classic 200S |             | |
-| Classic 300S | ✔           | ✔ |
-| Dual 200S |             | |
-| LV600S |             | ✔ |
-| OasisMist |             | ✔ |
-| Superior 6000S |            | ✔ |
-| Sprout Humidifier |             | |
+| Device Name | Night Light | RGB Night Light | Warm Mist |
+| ------ | ----- | ----- | ----- |
+| Classic 200S | | | |
+| Classic 300S | ✔ | | ✔ |
+| Dual 200S | | | |
+| LV600S | | | ✔ |
+| OasisMist 4.5L | | ✔ | ✔ |
+| Superior 6000S | | | ✔ |
+| Sprout Humidifier | | | |
+
+The OasisMist 4.5L (`LUH-O451S-WEU`) exposes an RGB nightlight through
+[`set_rgb_nightlight`][pyvesync.devices.vesynchumidifier.VeSyncHumid200300S.set_rgb_nightlight].
+Other models with the same hardware may work by adding the
+`HumidifierFeatures.RGB_NIGHTLIGHT` feature flag, but only the OasisMist 4.5L has
+been verified.
 
 ### Fans
 

--- a/src/pyvesync/base_devices/humidifier_base.py
+++ b/src/pyvesync/base_devices/humidifier_base.py
@@ -76,6 +76,13 @@ class HumidifierState(DeviceState):
         'nightlight_brightness',
         'nightlight_color_temp',
         'nightlight_status',
+        'rgb_nightlight_blue',
+        'rgb_nightlight_brightness',
+        'rgb_nightlight_color_mode',
+        'rgb_nightlight_green',
+        'rgb_nightlight_red',
+        'rgb_nightlight_set_time',
+        'rgb_nightlight_status',
         'temperature',
         'warm_mist_enabled',
         'warm_mist_level',
@@ -112,6 +119,13 @@ class HumidifierState(DeviceState):
         self.mode: str | None = None
         self.nightlight_brightness: int | None = None
         self.nightlight_status: str | None = None
+        self.rgb_nightlight_status: str | None = None
+        self.rgb_nightlight_brightness: int | None = None
+        self.rgb_nightlight_red: int | None = None
+        self.rgb_nightlight_green: int | None = None
+        self.rgb_nightlight_blue: int | None = None
+        self.rgb_nightlight_color_mode: str | None = None
+        self.rgb_nightlight_set_time: float | None = None
         self.nightlight_color_temp: int | None = None
         self.warm_mist_enabled: bool | None = None
         self.warm_mist_level: int | None = None
@@ -290,6 +304,15 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
         return HumidifierFeatures.NIGHTLIGHT_BRIGHTNESS in self.features
 
     @property
+    def supports_rgb_nightlight(self) -> bool:
+        """Return True if the humidifier supports RGB nightlight.
+
+        Returns:
+            bool: True if RGB nightlight is supported, False otherwise.
+        """
+        return HumidifierFeatures.RGB_NIGHTLIGHT in self.features
+
+    @property
     def supports_drying_mode(self) -> bool:
         """Return True if the humidifier supports drying mode."""
         return HumidifierFeatures.DRYING_MODE in self.features
@@ -459,6 +482,33 @@ class VeSyncHumidifier(VeSyncBaseToggleDevice):
             logger.error('Nightlight is not supported for this device.')
             return False
         logger.error('Nightlight has not been configured.')
+        return False
+
+    async def set_rgb_nightlight(
+        self,
+        power: bool | None = None,
+        brightness: int | None = None,
+        red: int | None = None,
+        green: int | None = None,
+        blue: int | None = None,
+    ) -> bool:
+        """Set RGB nightlight state and color.
+
+        Args:
+            power: Turn nightlight on (True) or off (False).
+            brightness: Brightness level (0-100).
+            red: Red color value (0-255).
+            green: Green color value (0-255).
+            blue: Blue color value (0-255).
+
+        Returns:
+            bool: Success of request.
+        """
+        del power, brightness, red, green, blue
+        if not self.supports_rgb_nightlight:
+            logger.error('RGB Nightlight is not supported for this device.')
+            return False
+        logger.error('RGB Nightlight has not been configured.')
         return False
 
     async def set_warm_level(self, warm_level: int) -> bool:

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -497,6 +497,7 @@ class HumidifierFeatures(Features):
         WARM_MIST: Warm mist status.
         AUTO_STOP: Auto stop when target humidity is reached.
             Different from auto, which adjusts fan level to maintain humidity.
+        RGB_NIGHTLIGHT: RGB nightlight with color control.
     """
 
     ONOFF = 'onoff'
@@ -507,6 +508,7 @@ class HumidifierFeatures(Features):
     AUTO_STOP = 'auto_stop'
     NIGHTLIGHT_BRIGHTNESS = 'nightlight_brightness'
     DRYING_MODE = 'drying_mode'
+    RGB_NIGHTLIGHT = 'rgb_nightlight'
 
 
 class PurifierFeatures(Features):

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -74,6 +74,10 @@ STATUS_OK = 200
 KELVIN_MIN = 2700
 KELVIN_MAX = 6500
 
+# RGB nightlight constants
+RGB_STALE_DATA_TIMEOUT = 180  # Seconds to ignore stale API data after setting values
+RGB_FULL_BRIGHTNESS = 100  # Full brightness percentage
+
 
 class ProductLines(StrEnum):
     """High level product line."""

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -684,7 +684,11 @@ humidifier_modules = [
     HumidifierMap(
         class_name='VeSyncHumid200300S',
         dev_types=['LUH-O451S-WEU'],
-        features=[HumidifierFeatures.WARM_MIST, HumidifierFeatures.AUTO_STOP],
+        features=[
+            HumidifierFeatures.WARM_MIST,
+            HumidifierFeatures.AUTO_STOP,
+            HumidifierFeatures.RGB_NIGHTLIGHT,
+        ],
         mist_modes={
             HumidifierModes.AUTO: 'auto',
             HumidifierModes.SLEEP: 'sleep',

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -327,14 +327,14 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
 
     # 8-color gradient used by VeSync app for RGB nightlight color slider
     _RGB_NIGHTLIGHT_GRADIENT: ClassVar[list[tuple[int, int, int]]] = [
-        (252, 50, 0),    # #fc3200 - Red (position 0)
-        (255, 171, 2),   # #ffab02 - Orange (position ~14.3)
-        (181, 255, 0),   # #b5ff00 - Yellow-Green (position ~28.6)
-        (2, 255, 120),   # #02ff78 - Green (position ~42.9)
-        (3, 200, 254),   # #03c8fe - Cyan (position ~57.1)
-        (0, 40, 255),    # #0028ff - Blue (position ~71.4)
-        (220, 0, 255),   # #dc00ff - Purple (position ~85.7)
-        (254, 0, 60),    # #fe003c - Pink/Red (position 100)
+        (252, 50, 0),  # #fc3200 - Red (position 0)
+        (255, 171, 2),  # #ffab02 - Orange (position ~14.3)
+        (181, 255, 0),  # #b5ff00 - Yellow-Green (position ~28.6)
+        (2, 255, 120),  # #02ff78 - Green (position ~42.9)
+        (3, 200, 254),  # #03c8fe - Cyan (position ~57.1)
+        (0, 40, 255),  # #0028ff - Blue (position ~71.4)
+        (220, 0, 255),  # #dc00ff - Purple (position ~85.7)
+        (254, 0, 60),  # #fe003c - Pink/Red (position 100)
     ]
 
     @staticmethod
@@ -452,8 +452,7 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
                 fraction = step / 100.0
                 interp_color = cls._interpolate_color(color1, color2, fraction)
                 distance = cls._color_distance(
-                    red, green, blue,
-                    interp_color[0], interp_color[1], interp_color[2]
+                    red, green, blue, interp_color[0], interp_color[1], interp_color[2]
                 )
 
                 if distance < best_distance:

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -327,7 +327,7 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
         brightness = 100 if toggle else 0
         return await self.set_nightlight_brightness(brightness)
 
-    async def set_rgb_nightlight(
+    async def set_rgb_nightlight(  # noqa: C901, PLR0912
         self,
         power: bool | None = None,
         brightness: int | None = None,
@@ -339,7 +339,8 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
 
         Args:
             power: Turn nightlight on (True) or off (False).
-            brightness: Brightness level (40-100). Values below 40 will be clamped.
+            brightness: Brightness level (0-100); values below 40 are raised to
+                the device minimum of 40. Out-of-range values are rejected.
             red: Red color value (0-255).
             green: Green color value (0-255).
             blue: Blue color value (0-255).
@@ -351,39 +352,57 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
             logger.warning('RGB Nightlight is not supported for %s', self.device_name)
             return False
 
-        # API requires all fields, so use current state for any not provided
+        # API requires all fields, so use current state for any not provided.
         if power is not None:
             action = 'on' if power else 'off'
         else:
             action = self.state.rgb_nightlight_status or 'on'
+        turning_off = action == 'off'
 
+        # Coalesce with `is None` so a legitimately stored 0 channel survives.
         if brightness is None:
-            brightness = self.state.rgb_nightlight_brightness or 40
-
+            brightness = (
+                self.state.rgb_nightlight_brightness
+                if self.state.rgb_nightlight_brightness is not None
+                else 40
+            )
         if red is None:
-            red = self.state.rgb_nightlight_red or 255
+            red = (
+                self.state.rgb_nightlight_red
+                if self.state.rgb_nightlight_red is not None
+                else 255
+            )
         if green is None:
-            green = self.state.rgb_nightlight_green or 255
+            green = (
+                self.state.rgb_nightlight_green
+                if self.state.rgb_nightlight_green is not None
+                else 255
+            )
         if blue is None:
-            blue = self.state.rgb_nightlight_blue or 255
-
-        # Brightness range is 40-100 per VeSync app
-        brightness = max(40, min(100, brightness))
-
-        # Clamp RGB values to valid range
-        red = max(0, min(255, red))
-        green = max(0, min(255, green))
-        blue = max(0, min(255, blue))
-
+            blue = (
+                self.state.rgb_nightlight_blue
+                if self.state.rgb_nightlight_blue is not None
+                else 255
+            )
         color_mode = self.state.rgb_nightlight_color_mode or 'color'
 
-        # Calculate colorSliderLocation from the base RGB color (at full brightness)
+        # Validate and reject rather than silently clamping bad input.
+        if not Validators.validate_range(brightness, 0, 100):
+            logger.warning('Brightness must be between 0 and 100')
+            return False
+        if not Validators.validate_rgb(red, green, blue):
+            logger.warning('RGB values must be between 0 and 255')
+            return False
+
+        # Device minimum brightness is 40 per the VeSync app.
+        brightness = max(40, brightness)
+
+        # Calculate colorSliderLocation from the base RGB color (full brightness).
         color_slider_location = RGBNightlightColor.rgb_to_color_slider_location(
             red, green, blue
         )
 
-        # Apply brightness to RGB values - the VeSync app sends brightness-adjusted
-        # RGB values to the API, not raw colors with separate brightness.
+        # The VeSync app sends brightness-adjusted RGB, not raw color + brightness.
         # From decompiled app: yv/p.java method b() and RGBNightLightView.java
         if brightness != RGB_FULL_BRIGHTNESS:
             adj_red, adj_green, adj_blue = RGBNightlightColor.apply_brightness_to_rgb(
@@ -408,13 +427,18 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
         if r is None:
             return False
 
-        # Update state and record timestamp to ignore stale API responses
+        # Mark reachable like sibling setters, then update state and record the
+        # timestamp used to ignore stale API responses for a short window.
+        self.state.connection_status = ConnectionStatus.ONLINE
         self.state.rgb_nightlight_status = action
-        self.state.rgb_nightlight_brightness = brightness
-        self.state.rgb_nightlight_red = red
-        self.state.rgb_nightlight_green = green
-        self.state.rgb_nightlight_blue = blue
-        self.state.rgb_nightlight_color_mode = color_mode
+        # An off command must not overwrite the stored color/brightness so the
+        # previous setting is restored on the next power-on.
+        if not turning_off:
+            self.state.rgb_nightlight_brightness = brightness
+            self.state.rgb_nightlight_red = red
+            self.state.rgb_nightlight_green = green
+            self.state.rgb_nightlight_blue = blue
+            self.state.rgb_nightlight_color_mode = color_mode
         self.state.rgb_nightlight_set_time = time.time()
 
         return True

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -427,9 +427,8 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
         if r is None:
             return False
 
-        # Mark reachable like sibling setters, then update state and record the
-        # timestamp used to ignore stale API responses for a short window.
-        self.state.connection_status = ConnectionStatus.ONLINE
+        # process_dev_response already set connection_status; update local state
+        # and record the timestamp used to ignore stale API responses briefly.
         self.state.rgb_nightlight_status = action
         # An off command must not overwrite the stored color/brightness so the
         # previous setting is restored on the next power-on.

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -2,22 +2,28 @@
 
 from __future__ import annotations
 
-import colorsys
 import logging
 import time
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 import orjson
 from typing_extensions import deprecated
 
 from pyvesync.base_devices.humidifier_base import BreathingLampState, VeSyncHumidifier
-from pyvesync.const import ConnectionStatus, DeviceStatus, DryingModes
+from pyvesync.const import (
+    RGB_FULL_BRIGHTNESS,
+    RGB_STALE_DATA_TIMEOUT,
+    ConnectionStatus,
+    DeviceStatus,
+    DryingModes,
+)
 from pyvesync.models import humidifier_models as models
 from pyvesync.models.bypass_models import (
     ResultV2GetTimer,
     ResultV2GetTimerV2,
     ResultV2SetTimer,
 )
+from pyvesync.utils.colors import RGBNightlightColor
 from pyvesync.utils.device_mixins import BypassV2Mixin, process_bypassv2_result
 from pyvesync.utils.helpers import Helpers, Timer, Validators
 
@@ -28,10 +34,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-# RGB nightlight constants
-RGB_STALE_DATA_TIMEOUT = 180  # Seconds to ignore stale API data after setting values
-RGB_FULL_BRIGHTNESS = 100  # Full brightness percentage
 
 
 class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
@@ -103,47 +105,47 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
         if self.supports_warm_mist and resp_model.warm_level is not None:
             self.state.warm_mist_level = resp_model.warm_level
             self.state.warm_mist_enabled = resp_model.warm_enabled
-        # Handle RGB nightlight
         if self.supports_rgb_nightlight and resp_model.rgbNightLight is not None:
-            rgb = resp_model.rgbNightLight
-            # Skip updating RGB nightlight state if we recently set it
-            # The VeSync API returns stale data for several minutes after setting values
-            # so we ignore updates briefly after a set command
-            skip_rgb_update = (
-                self.state.rgb_nightlight_set_time is not None
-                and (time.time() - self.state.rgb_nightlight_set_time)
-                < RGB_STALE_DATA_TIMEOUT
-            )
-            if not skip_rgb_update:
-                self.state.rgb_nightlight_status = rgb.action
-                self.state.rgb_nightlight_brightness = rgb.brightness
-                self.state.rgb_nightlight_color_mode = rgb.colorMode
-                # The API uses brightness-adjusted RGB values. We need to store the
-                # "base" color (at full brightness) so that changing only brightness
-                # doesn't cause color drift. Normalize RGB back to full brightness.
-                brightness_adjusted = (
-                    rgb.brightness is not None
-                    and 0 < rgb.brightness < RGB_FULL_BRIGHTNESS
-                )
-                if brightness_adjusted:
-                    base_r, base_g, base_b = self._normalize_rgb_to_full_brightness(
-                        rgb.red, rgb.green, rgb.blue
-                    )
-                    self.state.rgb_nightlight_red = base_r
-                    self.state.rgb_nightlight_green = base_g
-                    self.state.rgb_nightlight_blue = base_b
-                else:
-                    self.state.rgb_nightlight_red = rgb.red
-                    self.state.rgb_nightlight_green = rgb.green
-                    self.state.rgb_nightlight_blue = rgb.blue
-                # Clear the set time since we've now received valid data from API
-                self.state.rgb_nightlight_set_time = None
+            self._set_rgb_nightlight_state(resp_model.rgbNightLight)
 
         config = resp_model.configuration
         if config is not None:
             self.state.auto_target_humidity = config.auto_target_humidity
             self.state.automatic_stop_config = config.automatic_stop
             self.state.display_set_status = DeviceStatus.from_bool(config.display)
+
+    def _set_rgb_nightlight_state(self, rgb: models.RGBNightLight) -> None:
+        # Skip updating RGB nightlight state if we recently set it. The
+        # VeSync API returns stale data for several minutes after setting
+        # values, so we ignore updates briefly after a set command.
+        if (
+            self.state.rgb_nightlight_set_time is not None
+            and (time.time() - self.state.rgb_nightlight_set_time)
+            < RGB_STALE_DATA_TIMEOUT
+        ):
+            return
+
+        self.state.rgb_nightlight_status = rgb.action
+        self.state.rgb_nightlight_brightness = rgb.brightness
+        self.state.rgb_nightlight_color_mode = rgb.colorMode
+        # The API uses brightness-adjusted RGB values. Store the base color
+        # at full brightness so that changing only brightness doesn't drift.
+        brightness_adjusted = (
+            rgb.brightness is not None and 0 < rgb.brightness < RGB_FULL_BRIGHTNESS
+        )
+        if brightness_adjusted:
+            base_r, base_g, base_b = RGBNightlightColor.normalize_to_full_brightness(
+                rgb.red, rgb.green, rgb.blue
+            )
+            self.state.rgb_nightlight_red = base_r
+            self.state.rgb_nightlight_green = base_g
+            self.state.rgb_nightlight_blue = base_b
+        else:
+            self.state.rgb_nightlight_red = rgb.red
+            self.state.rgb_nightlight_green = rgb.green
+            self.state.rgb_nightlight_blue = rgb.blue
+        # Clear the set time since we've now received valid data from API
+        self.state.rgb_nightlight_set_time = None
 
     async def get_details(self) -> None:
         r_dict = await self.call_bypassv2_api('getHumidifierStatus')
@@ -325,142 +327,6 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
         brightness = 100 if toggle else 0
         return await self.set_nightlight_brightness(brightness)
 
-    # 8-color gradient used by VeSync app for RGB nightlight color slider
-    _RGB_NIGHTLIGHT_GRADIENT: ClassVar[list[tuple[int, int, int]]] = [
-        (252, 50, 0),  # #fc3200 - Red (position 0)
-        (255, 171, 2),  # #ffab02 - Orange (position ~14.3)
-        (181, 255, 0),  # #b5ff00 - Yellow-Green (position ~28.6)
-        (2, 255, 120),  # #02ff78 - Green (position ~42.9)
-        (3, 200, 254),  # #03c8fe - Cyan (position ~57.1)
-        (0, 40, 255),  # #0028ff - Blue (position ~71.4)
-        (220, 0, 255),  # #dc00ff - Purple (position ~85.7)
-        (254, 0, 60),  # #fe003c - Pink/Red (position 100)
-    ]
-
-    @staticmethod
-    def _color_distance(r1: int, g1: int, b1: int, r2: int, g2: int, b2: int) -> float:
-        """Calculate Euclidean distance between two RGB colors.
-
-        From decompiled app: yv/p.java method c()
-        """
-        return ((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2) ** 0.5
-
-    @staticmethod
-    def _interpolate_color(
-        color1: tuple[int, int, int], color2: tuple[int, int, int], fraction: float
-    ) -> tuple[int, int, int]:
-        """Linearly interpolate between two colors."""
-        r = int(color1[0] + (color2[0] - color1[0]) * fraction)
-        g = int(color1[1] + (color2[1] - color1[1]) * fraction)
-        b = int(color1[2] + (color2[2] - color1[2]) * fraction)
-        return (r, g, b)
-
-    @staticmethod
-    def _apply_brightness_to_rgb(
-        red: int, green: int, blue: int, brightness: int
-    ) -> tuple[int, int, int]:
-        """Apply brightness to RGB color using HSV color space.
-
-        The VeSync app applies brightness by converting to HSV, setting the V
-        (value) component to brightness/100, then converting back to RGB.
-
-        From decompiled app: yv/p.java method b()
-
-        Args:
-            red: Red value (0-255).
-            green: Green value (0-255).
-            blue: Blue value (0-255).
-            brightness: Brightness level (0-100).
-
-        Returns:
-            tuple: Brightness-adjusted (red, green, blue) values.
-        """
-        # Convert RGB to HSV
-        h, s, _ = colorsys.rgb_to_hsv(red / 255.0, green / 255.0, blue / 255.0)
-
-        # Set V (value/brightness) to brightness/100
-        v = brightness / 100.0
-
-        # Convert back to RGB
-        r, g, b = colorsys.hsv_to_rgb(h, s, v)
-        return (int(r * 255), int(g * 255), int(b * 255))
-
-    @staticmethod
-    def _normalize_rgb_to_full_brightness(
-        red: int, green: int, blue: int
-    ) -> tuple[int, int, int]:
-        """Normalize brightness-adjusted RGB back to full brightness (100%).
-
-        This is the inverse of _apply_brightness_to_rgb. Given RGB values that
-        have been dimmed, recover the original "full brightness" color by
-        setting HSV value to 1.0 while preserving hue and saturation.
-
-        Args:
-            red: Red value (0-255), brightness-adjusted.
-            green: Green value (0-255), brightness-adjusted.
-            blue: Blue value (0-255), brightness-adjusted.
-
-        Returns:
-            tuple: Normalized (red, green, blue) values at full brightness.
-        """
-        # Convert RGB to HSV
-        h, s, _ = colorsys.rgb_to_hsv(red / 255.0, green / 255.0, blue / 255.0)
-
-        # Restore V to 1.0 (full brightness) while keeping hue and saturation
-        v = 1.0
-
-        # Convert back to RGB
-        r, g, b = colorsys.hsv_to_rgb(h, s, v)
-        return (int(r * 255), int(g * 255), int(b * 255))
-
-    @classmethod
-    def _rgb_to_color_slider_location(cls, red: int, green: int, blue: int) -> int:
-        """Convert RGB values to colorSliderLocation (0-100).
-
-        The VeSync app uses an 8-color gradient for the color slider.
-        This finds the closest position on that gradient by checking
-        each segment and finding where the input color best fits.
-
-        Note: Input RGB should be at full brightness for accurate results.
-        If the input has reduced brightness, first normalize it.
-
-        From decompiled app: yv/p.java (HumidifierColor.kt)
-
-        Args:
-            red: Red value (0-255).
-            green: Green value (0-255).
-            blue: Blue value (0-255).
-
-        Returns:
-            int: Color slider location (0-100).
-        """
-        gradient = cls._RGB_NIGHTLIGHT_GRADIENT
-        num_colors = len(gradient)
-        segment_size = 100.0 / (num_colors - 1)  # ~14.29 for 8 colors
-
-        best_position = 0.0
-        best_distance = float('inf')
-
-        # Check each segment of the gradient
-        for i in range(num_colors - 1):
-            color1 = gradient[i]
-            color2 = gradient[i + 1]
-            start_pos = i * segment_size
-
-            # Check multiple points along this segment for precision
-            for step in range(101):
-                fraction = step / 100.0
-                interp_color = cls._interpolate_color(color1, color2, fraction)
-                distance = cls._color_distance(
-                    red, green, blue, interp_color[0], interp_color[1], interp_color[2]
-                )
-
-                if distance < best_distance:
-                    best_distance = distance
-                    best_position = start_pos + (fraction * segment_size)
-
-        return round(best_position)
-
     async def set_rgb_nightlight(
         self,
         power: bool | None = None,
@@ -512,13 +378,15 @@ class VeSyncHumid200300S(BypassV2Mixin, VeSyncHumidifier):
         color_mode = self.state.rgb_nightlight_color_mode or 'color'
 
         # Calculate colorSliderLocation from the base RGB color (at full brightness)
-        color_slider_location = self._rgb_to_color_slider_location(red, green, blue)
+        color_slider_location = RGBNightlightColor.rgb_to_color_slider_location(
+            red, green, blue
+        )
 
         # Apply brightness to RGB values - the VeSync app sends brightness-adjusted
         # RGB values to the API, not raw colors with separate brightness.
         # From decompiled app: yv/p.java method b() and RGBNightLightView.java
         if brightness != RGB_FULL_BRIGHTNESS:
-            adj_red, adj_green, adj_blue = self._apply_brightness_to_rgb(
+            adj_red, adj_green, adj_blue = RGBNightlightColor.apply_brightness_to_rgb(
                 red, green, blue, brightness
             )
         else:

--- a/src/pyvesync/models/humidifier_models.py
+++ b/src/pyvesync/models/humidifier_models.py
@@ -62,6 +62,20 @@ class BypassV2InnerErrorResult(InnerHumidifierBaseResult):
 
 
 @dataclass
+class RGBNightLight(ResponseBaseModel):
+    """RGB Night Light Model for Humidifiers."""
+
+    action: str
+    colorMode: str
+    brightness: int
+    red: int
+    green: int
+    blue: int
+    speed: int = 0
+    colorSliderLocation: int = 0
+
+
+@dataclass
 class ClassicLVHumidResult(InnerHumidifierBaseResult):
     """Classic 200S Humidifier Result Model.
 
@@ -82,6 +96,7 @@ class ClassicLVHumidResult(InnerHumidifierBaseResult):
     warm_level: int | None = None
     night_light_brightness: int | None = None
     configuration: ClassicConfig | None = None
+    rgbNightLight: RGBNightLight | None = None
 
 
 @dataclass

--- a/src/pyvesync/utils/colors.py
+++ b/src/pyvesync/utils/colors.py
@@ -273,26 +273,6 @@ class RGBNightlightColor:
     ]
 
     @staticmethod
-    def color_distance(r1: int, g1: int, b1: int, r2: int, g2: int, b2: int) -> float:
-        """Calculate Euclidean distance between two RGB colors.
-
-        From decompiled app: yv/p.java method c()
-        """
-        return ((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2) ** 0.5
-
-    @staticmethod
-    def interpolate_color(
-        color1: tuple[int, int, int],
-        color2: tuple[int, int, int],
-        fraction: float,
-    ) -> tuple[int, int, int]:
-        """Linearly interpolate between two colors."""
-        r = int(color1[0] + (color2[0] - color1[0]) * fraction)
-        g = int(color1[1] + (color2[1] - color1[1]) * fraction)
-        b = int(color1[2] + (color2[2] - color1[2]) * fraction)
-        return (r, g, b)
-
-    @staticmethod
     def apply_brightness_to_rgb(
         red: int, green: int, blue: int, brightness: int
     ) -> tuple[int, int, int]:
@@ -367,30 +347,31 @@ class RGBNightlightColor:
         """
         gradient = cls.GRADIENT
         num_colors = len(gradient)
-        segment_size = 100.0 / (num_colors - 1)  # ~14.29 for 8 colors
+        segment_size = 100.0 / (num_colors - 1)
 
         best_position = 0.0
-        best_distance = float('inf')
+        best_distance_sq = float('inf')
 
         for i in range(num_colors - 1):
-            color1 = gradient[i]
-            color2 = gradient[i + 1]
-            start_pos = i * segment_size
+            ax, ay, az = gradient[i]
+            bx, by, bz = gradient[i + 1]
+            dx, dy, dz = bx - ax, by - ay, bz - az
+            seg_len_sq = dx * dx + dy * dy + dz * dz
+            if seg_len_sq == 0:
+                fraction = 0.0
+            else:
+                fraction = (
+                    (red - ax) * dx + (green - ay) * dy + (blue - az) * dz
+                ) / seg_len_sq
+                fraction = max(0.0, min(1.0, fraction))
 
-            for step in range(101):
-                fraction = step / 100.0
-                interp_color = cls.interpolate_color(color1, color2, fraction)
-                distance = cls.color_distance(
-                    red,
-                    green,
-                    blue,
-                    interp_color[0],
-                    interp_color[1],
-                    interp_color[2],
-                )
+            cx = ax + dx * fraction
+            cy = ay + dy * fraction
+            cz = az + dz * fraction
+            distance_sq = (red - cx) ** 2 + (green - cy) ** 2 + (blue - cz) ** 2
 
-                if distance < best_distance:
-                    best_distance = distance
-                    best_position = start_pos + (fraction * segment_size)
+            if distance_sq < best_distance_sq:
+                best_distance_sq = distance_sq
+                best_position = i * segment_size + fraction * segment_size
 
         return round(best_position)

--- a/src/pyvesync/utils/colors.py
+++ b/src/pyvesync/utils/colors.py
@@ -312,10 +312,12 @@ class RGBNightlightColor:
         Returns:
             tuple: Brightness-adjusted (red, green, blue) values.
         """
+        if max(red, green, blue) == 0:
+            return (0, 0, 0)
         h, s, _ = colorsys.rgb_to_hsv(red / 255.0, green / 255.0, blue / 255.0)
         v = brightness / 100.0
         r, g, b = colorsys.hsv_to_rgb(h, s, v)
-        return (int(r * 255), int(g * 255), int(b * 255))
+        return (round(r * 255), round(g * 255), round(b * 255))
 
     @staticmethod
     def normalize_to_full_brightness(
@@ -335,10 +337,12 @@ class RGBNightlightColor:
         Returns:
             tuple: Normalized (red, green, blue) values at full brightness.
         """
+        if max(red, green, blue) == 0:
+            return (0, 0, 0)
         h, s, _ = colorsys.rgb_to_hsv(red / 255.0, green / 255.0, blue / 255.0)
         v = 1.0
         r, g, b = colorsys.hsv_to_rgb(h, s, v)
-        return (int(r * 255), int(g * 255), int(b * 255))
+        return (round(r * 255), round(g * 255), round(b * 255))
 
     @classmethod
     def rgb_to_color_slider_location(cls, red: int, green: int, blue: int) -> int:

--- a/src/pyvesync/utils/colors.py
+++ b/src/pyvesync/utils/colors.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import colorsys
 import logging
 from dataclasses import InitVar, dataclass
+from typing import ClassVar
 
 from pyvesync.utils.helpers import Validators
 
@@ -248,3 +249,144 @@ class Color:
             float(round(hsv_tuple[1] * hsv_factors[1], 2)),
             float(round(hsv_tuple[2] * hsv_factors[2], 0)),
         )
+
+
+class RGBNightlightColor:
+    """Color helpers for RGB nightlight devices.
+
+    Encapsulates the 8-color gradient used by the VeSync app for the RGB
+    nightlight color slider, along with the geometry needed to map an
+    arbitrary RGB color to a slider position and to apply or recover
+    brightness.
+    """
+
+    # 8-color gradient used by VeSync app for RGB nightlight color slider
+    GRADIENT: ClassVar[list[tuple[int, int, int]]] = [
+        (252, 50, 0),  # #fc3200 - Red (position 0)
+        (255, 171, 2),  # #ffab02 - Orange (position ~14.3)
+        (181, 255, 0),  # #b5ff00 - Yellow-Green (position ~28.6)
+        (2, 255, 120),  # #02ff78 - Green (position ~42.9)
+        (3, 200, 254),  # #03c8fe - Cyan (position ~57.1)
+        (0, 40, 255),  # #0028ff - Blue (position ~71.4)
+        (220, 0, 255),  # #dc00ff - Purple (position ~85.7)
+        (254, 0, 60),  # #fe003c - Pink/Red (position 100)
+    ]
+
+    @staticmethod
+    def color_distance(r1: int, g1: int, b1: int, r2: int, g2: int, b2: int) -> float:
+        """Calculate Euclidean distance between two RGB colors.
+
+        From decompiled app: yv/p.java method c()
+        """
+        return ((r1 - r2) ** 2 + (g1 - g2) ** 2 + (b1 - b2) ** 2) ** 0.5
+
+    @staticmethod
+    def interpolate_color(
+        color1: tuple[int, int, int],
+        color2: tuple[int, int, int],
+        fraction: float,
+    ) -> tuple[int, int, int]:
+        """Linearly interpolate between two colors."""
+        r = int(color1[0] + (color2[0] - color1[0]) * fraction)
+        g = int(color1[1] + (color2[1] - color1[1]) * fraction)
+        b = int(color1[2] + (color2[2] - color1[2]) * fraction)
+        return (r, g, b)
+
+    @staticmethod
+    def apply_brightness_to_rgb(
+        red: int, green: int, blue: int, brightness: int
+    ) -> tuple[int, int, int]:
+        """Apply brightness to RGB color using HSV color space.
+
+        The VeSync app applies brightness by converting to HSV, setting the V
+        (value) component to brightness/100, then converting back to RGB.
+
+        From decompiled app: yv/p.java method b()
+
+        Args:
+            red: Red value (0-255).
+            green: Green value (0-255).
+            blue: Blue value (0-255).
+            brightness: Brightness level (0-100).
+
+        Returns:
+            tuple: Brightness-adjusted (red, green, blue) values.
+        """
+        h, s, _ = colorsys.rgb_to_hsv(red / 255.0, green / 255.0, blue / 255.0)
+        v = brightness / 100.0
+        r, g, b = colorsys.hsv_to_rgb(h, s, v)
+        return (int(r * 255), int(g * 255), int(b * 255))
+
+    @staticmethod
+    def normalize_to_full_brightness(
+        red: int, green: int, blue: int
+    ) -> tuple[int, int, int]:
+        """Normalize brightness-adjusted RGB back to full brightness (100%).
+
+        Inverse of `apply_brightness_to_rgb`. Given RGB values that have been
+        dimmed, recover the original "full brightness" color by setting HSV
+        value to 1.0 while preserving hue and saturation.
+
+        Args:
+            red: Red value (0-255), brightness-adjusted.
+            green: Green value (0-255), brightness-adjusted.
+            blue: Blue value (0-255), brightness-adjusted.
+
+        Returns:
+            tuple: Normalized (red, green, blue) values at full brightness.
+        """
+        h, s, _ = colorsys.rgb_to_hsv(red / 255.0, green / 255.0, blue / 255.0)
+        v = 1.0
+        r, g, b = colorsys.hsv_to_rgb(h, s, v)
+        return (int(r * 255), int(g * 255), int(b * 255))
+
+    @classmethod
+    def rgb_to_color_slider_location(cls, red: int, green: int, blue: int) -> int:
+        """Convert RGB values to colorSliderLocation (0-100).
+
+        The VeSync app uses an 8-color gradient for the color slider. This
+        finds the closest position on that gradient by checking each segment
+        and finding where the input color best fits.
+
+        Note: Input RGB should be at full brightness for accurate results.
+        If the input has reduced brightness, first normalize it.
+
+        From decompiled app: yv/p.java (HumidifierColor.kt)
+
+        Args:
+            red: Red value (0-255).
+            green: Green value (0-255).
+            blue: Blue value (0-255).
+
+        Returns:
+            int: Color slider location (0-100).
+        """
+        gradient = cls.GRADIENT
+        num_colors = len(gradient)
+        segment_size = 100.0 / (num_colors - 1)  # ~14.29 for 8 colors
+
+        best_position = 0.0
+        best_distance = float('inf')
+
+        for i in range(num_colors - 1):
+            color1 = gradient[i]
+            color2 = gradient[i + 1]
+            start_pos = i * segment_size
+
+            for step in range(101):
+                fraction = step / 100.0
+                interp_color = cls.interpolate_color(color1, color2, fraction)
+                distance = cls.color_distance(
+                    red,
+                    green,
+                    blue,
+                    interp_color[0],
+                    interp_color[1],
+                    interp_color[2],
+                )
+
+                if distance < best_distance:
+                    best_distance = distance
+                    best_position = start_pos + (fraction * segment_size)
+
+        return round(best_position)

--- a/src/tests/api/vesynchumidifier/LUH-O451S-WEU.yaml
+++ b/src/tests/api/vesynchumidifier/LUH-O451S-WEU.yaml
@@ -108,6 +108,40 @@ set_mist_level:
     userCountryCode: US
   method: post
   url: /cloud/v2/deviceManaged/bypassV2
+set_rgb_nightlight:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: LUH-O451S-WEU-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LUH-O451S-WEU-CID
+    method: bypassV2
+    payload:
+      data:
+        action: 'on'
+        blue: 0
+        brightness: 100
+        colorMode: color
+        colorSliderLocation: 0
+        green: 50
+        red: 252
+        speed: 0
+      method: setLightStatus
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
 turn_off:
   headers:
     Content-Type: application/json; charset=UTF-8

--- a/src/tests/call_json_humidifiers.py
+++ b/src/tests/call_json_humidifiers.py
@@ -70,6 +70,13 @@ class HumidifierDefaults:
     nightlight_status = DeviceStatus.OFF
     nightlight_brightness = 0
     nightlight_color_temperature = 4000
+    # RGB Nightlight Defaults
+    rgb_nightlight_status = "on"
+    rgb_nightlight_color_mode = "color"
+    rgb_nightlight_brightness = 100
+    rgb_nightlight_red = 252
+    rgb_nightlight_green = 50
+    rgb_nightlight_blue = 0
     # Drying Defaults
     drying_level = 1
     drying_state = DryingModes.DONE
@@ -190,6 +197,16 @@ HUMIDIFIER_DETAILS: dict[str, Any] = {
         "warm_enabled": HumidifierDefaults.warm_mist_enabled,
         "warm_level": HumidifierDefaults.warm_mist_level,
         "automatic_stop_reach_target": HumidifierDefaults.auto_stop_reached,
+        "rgbNightLight": {
+            "action": HumidifierDefaults.rgb_nightlight_status,
+            "colorMode": HumidifierDefaults.rgb_nightlight_color_mode,
+            "brightness": HumidifierDefaults.rgb_nightlight_brightness,
+            "red": HumidifierDefaults.rgb_nightlight_red,
+            "green": HumidifierDefaults.rgb_nightlight_green,
+            "blue": HumidifierDefaults.rgb_nightlight_blue,
+            "speed": 0,
+            "colorSliderLocation": 0,
+        },
         "configuration": {
             "auto_target_humidity": HumidifierDefaults.target_humidity,
             "display": HumidifierDefaults.display_config,

--- a/src/tests/test_colors.py
+++ b/src/tests/test_colors.py
@@ -1,5 +1,7 @@
 """Unit tests for pyvesync.utils.colors.RGBNightlightColor."""
 
+import pytest
+
 from pyvesync.utils.colors import RGBNightlightColor
 
 
@@ -25,3 +27,20 @@ def test_apply_brightness_rounds_not_truncates():
     # (255,128,64) scaled to value 0.502 -> green 128.5 rounds to 128 (int->127 earlier)
     red, green, blue = RGBNightlightColor.apply_brightness_to_rgb(255, 129, 64, 51)
     assert green == 66  # round(129/255*0.51*255) == round(65.79) == 66
+
+
+@pytest.mark.parametrize(
+    'index',
+    list(range(len(RGBNightlightColor.GRADIENT))),
+)
+def test_slider_anchor_maps_to_its_position(index):
+    """Each gradient anchor maps to its evenly-spaced slider position."""
+    red, green, blue = RGBNightlightColor.GRADIENT[index]
+    expected = round(index * (100.0 / (len(RGBNightlightColor.GRADIENT) - 1)))
+    assert RGBNightlightColor.rgb_to_color_slider_location(red, green, blue) == expected
+
+
+def test_slider_location_within_bounds():
+    """Arbitrary colours map inside the 0..100 slider range."""
+    loc = RGBNightlightColor.rgb_to_color_slider_location(10, 200, 30)
+    assert 0 <= loc <= 100

--- a/src/tests/test_colors.py
+++ b/src/tests/test_colors.py
@@ -1,0 +1,27 @@
+"""Unit tests for pyvesync.utils.colors.RGBNightlightColor."""
+
+from pyvesync.utils.colors import RGBNightlightColor
+
+
+def test_normalize_black_stays_black():
+    """Black (0,0,0) must not normalize to white."""
+    assert RGBNightlightColor.normalize_to_full_brightness(0, 0, 0) == (0, 0, 0)
+
+
+def test_apply_brightness_black_stays_black():
+    """Applying brightness to black must stay black, not become gray."""
+    assert RGBNightlightColor.apply_brightness_to_rgb(0, 0, 0, 50) == (0, 0, 0)
+
+
+def test_normalize_recovers_full_brightness_color():
+    """A saturated hue dimmed then normalized recovers a max-channel of 255."""
+    dimmed = RGBNightlightColor.apply_brightness_to_rgb(252, 50, 0, 40)
+    base = RGBNightlightColor.normalize_to_full_brightness(*dimmed)
+    assert max(base) == 255
+
+
+def test_apply_brightness_rounds_not_truncates():
+    """round() keeps the green channel at 128 where int() would give 127."""
+    # (255,128,64) scaled to value 0.502 -> green 128.5 rounds to 128 (int->127 earlier)
+    red, green, blue = RGBNightlightColor.apply_brightness_to_rgb(255, 129, 64, 51)
+    assert green == 66  # round(129/255*0.51*255) == round(65.79) == 66

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -33,7 +33,7 @@ import pyvesync.const as const
 from pyvesync.base_devices.humidifier_base import VeSyncHumidifier
 from base_test_cases import TestBase
 from utils import assert_test, parse_args
-from defaults import TestDefaults
+from defaults import TestDefaults, build_bypass_v2_response
 import call_json_humidifiers
 
 
@@ -282,3 +282,62 @@ class TestHumidifiers(TestBase):
         assert assert_test(
             method_call, all_kwargs, setup_entry, self.write_api, self.overwrite
         )
+
+    RGB_DEVICE = "LUH-O451S-WEU"
+
+    def _rgb_success(self):
+        """Return a successful BypassV2 envelope for set calls."""
+        return (build_bypass_v2_response(inner_result={}), 200)
+
+    def test_set_rgb_preserves_zero_channel(self):
+        """A stored 0 channel must not be replaced by 255 on a partial update."""
+        self.mock_api.return_value = self._rgb_success()
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        obj.state.rgb_nightlight_red = 0
+        obj.state.rgb_nightlight_green = 255
+        obj.state.rgb_nightlight_blue = 0
+        result = self.run_in_loop(obj.set_rgb_nightlight, brightness=50)
+        assert result is True
+        assert obj.state.rgb_nightlight_red == 0
+        assert obj.state.rgb_nightlight_blue == 0
+
+    def test_set_rgb_rejects_out_of_range_rgb(self):
+        """Out-of-range RGB is rejected, not silently clamped."""
+        self.mock_api.return_value = self._rgb_success()
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        result = self.run_in_loop(obj.set_rgb_nightlight, red=999, green=0, blue=0)
+        assert result is False
+
+    def test_set_rgb_off_preserves_color_state(self):
+        """Turning the light off must not overwrite stored brightness/color."""
+        self.mock_api.return_value = self._rgb_success()
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        obj.state.rgb_nightlight_red = 10
+        obj.state.rgb_nightlight_green = 20
+        obj.state.rgb_nightlight_blue = 30
+        obj.state.rgb_nightlight_brightness = 80
+        result = self.run_in_loop(obj.set_rgb_nightlight, power=False)
+        assert result is True
+        assert obj.state.rgb_nightlight_status == "off"
+        assert obj.state.rgb_nightlight_red == 10
+        assert obj.state.rgb_nightlight_brightness == 80
+
+    def test_set_rgb_on_sets_status(self):
+        """power=True records the nightlight status as 'on'."""
+        self.mock_api.return_value = self._rgb_success()
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        obj.state.rgb_nightlight_status = "off"
+        result = self.run_in_loop(
+            obj.set_rgb_nightlight, power=True, brightness=60, red=10, green=20, blue=30
+        )
+        assert result is True
+        assert obj.state.rgb_nightlight_status == "on"
+
+    def test_set_rgb_sets_connection_online(self):
+        """A successful set marks the device online like sibling setters."""
+        self.mock_api.return_value = self._rgb_success()
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        obj.state.connection_status = const.ConnectionStatus.OFFLINE
+        result = self.run_in_loop(obj.set_rgb_nightlight, brightness=60, red=10, green=20, blue=30)
+        assert result is True
+        assert obj.state.connection_status == const.ConnectionStatus.ONLINE

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -309,17 +309,18 @@ class TestHumidifiers(TestBase):
         assert result is False
 
     def test_set_rgb_off_preserves_color_state(self):
-        """Turning the light off must not overwrite stored brightness/color."""
+        """Turning off must not clobber a stored 0-channel color or brightness."""
         self.mock_api.return_value = self._rgb_success()
         obj = self.get_device("humidifiers", self.RGB_DEVICE)
-        obj.state.rgb_nightlight_red = 10
-        obj.state.rgb_nightlight_green = 20
-        obj.state.rgb_nightlight_blue = 30
+        obj.state.rgb_nightlight_red = 0  # buggy code would coalesce 0 -> 255
+        obj.state.rgb_nightlight_green = 255
+        obj.state.rgb_nightlight_blue = 0
         obj.state.rgb_nightlight_brightness = 80
         result = self.run_in_loop(obj.set_rgb_nightlight, power=False)
         assert result is True
         assert obj.state.rgb_nightlight_status == "off"
-        assert obj.state.rgb_nightlight_red == 10
+        assert obj.state.rgb_nightlight_red == 0  # preserved, not 255
+        assert obj.state.rgb_nightlight_blue == 0
         assert obj.state.rgb_nightlight_brightness == 80
 
     def test_set_rgb_on_sets_status(self):
@@ -334,7 +335,7 @@ class TestHumidifiers(TestBase):
         assert obj.state.rgb_nightlight_status == "on"
 
     def test_set_rgb_sets_connection_online(self):
-        """A successful set marks the device online like sibling setters."""
+        """A successful set marks the device online (via process_dev_response)."""
         self.mock_api.return_value = self._rgb_success()
         obj = self.get_device("humidifiers", self.RGB_DEVICE)
         obj.state.connection_status = const.ConnectionStatus.OFFLINE

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -121,6 +121,9 @@ class TestHumidifiers(TestBase):
         "LUH-A602S-WUS": [["set_warm_level", {"warm_level": 3}]],
         "LUH-A603S-WUS": [["set_warm_level", {"warm_level": 3}]],
         "LEH-S601S": [["turn_off_drying_mode"]],
+        "LUH-O451S-WEU": [
+            ["set_rgb_nightlight", {"power": True, "brightness": 100, "red": 252, "green": 50, "blue": 0}],
+        ],
     }
 
     def test_details(self, setup_entry, method):

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -342,3 +342,32 @@ class TestHumidifiers(TestBase):
         result = self.run_in_loop(obj.set_rgb_nightlight, brightness=60, red=10, green=20, blue=30)
         assert result is True
         assert obj.state.connection_status == const.ConnectionStatus.ONLINE
+
+    def test_rgb_state_normalizes_dimmed_read(self):
+        """A dimmed API color is stored as a full-brightness base (max channel 255)."""
+        from pyvesync.models.humidifier_models import RGBNightLight
+
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        dimmed = RGBNightLight(
+            action="on", colorMode="color", brightness=40, red=102, green=20, blue=0
+        )
+        obj._set_rgb_nightlight_state(dimmed)
+        assert obj.state.rgb_nightlight_status == "on"
+        assert max(
+            obj.state.rgb_nightlight_red,
+            obj.state.rgb_nightlight_green,
+            obj.state.rgb_nightlight_blue,
+        ) == 255
+
+    def test_rgb_state_black_stays_black_on_read(self):
+        """A dimmed all-zero color must not be stored as white."""
+        from pyvesync.models.humidifier_models import RGBNightLight
+
+        obj = self.get_device("humidifiers", self.RGB_DEVICE)
+        black = RGBNightLight(
+            action="on", colorMode="color", brightness=40, red=0, green=0, blue=0
+        )
+        obj._set_rgb_nightlight_state(black)
+        assert obj.state.rgb_nightlight_red == 0
+        assert obj.state.rgb_nightlight_green == 0
+        assert obj.state.rgb_nightlight_blue == 0


### PR DESCRIPTION
## Summary

Adds RGB nightlight control support for the `VeSyncHumid200300S` device class, specifically for the **LUH-O451S-WEU** (OasisMist 4.5L) humidifier model.

This addresses missing nightlight functionality that prevents Home Assistant from creating light entities for humidifiers with RGB nightlight features. Related issue: [home-assistant/core#160387](https://github.com/home-assistant/core/issues/160387)

## Changes

- Added `HumidifierFeatures.RGB_NIGHTLIGHT` feature flag
- Added `supports_rgb_nightlight` property to base class
- Implemented `set_rgb_nightlight(power, brightness, red, green, blue)` method
- Added RGB nightlight state attributes (status, brightness, r/g/b, color_mode)

## API Quirks

1. **Brightness-adjusted RGB**: API expects RGB values pre-multiplied by brightness via HSV conversion
2. **Color slider location**: API requires a `colorSliderLocation` (0-100) mapped from an 8-color gradient
3. **!Stale API responses!**: After setting values, API returns old data for several minutes - implemented timeout to prevent state drift. This is sadly not working perfectly yet, I didn't find out how to improve this behavior or force the getHumidifierStatus to return the values we just set before. Maybe someone with more insight or time can improve this as it's also causing issues when updating the nightlight via App and then using this library. 

## Known Limitations

- Minimum brightness is 40% (enforced by VeSync app)
- Other models with RGB nightlights (e.g., LUH-D301S-WUSR) may work by adding the feature flag - only tested on LUH-O451S-WEU

## Testing

Tested on physical LUH-O451S-WEU device: power on/off, brightness, color changes, state refresh.

<img width="588" height="751" alt="image" src="https://github.com/user-attachments/assets/5f843e8a-677a-44e8-aa34-3b7d7016d215" />
