### PR TITLE
fix: set correct auto mode for LV600S

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ tools/__init__.py
 tools/vesyncdevice.py
 pyvesync.und
 .venv
+pyvesync-venv/
 
 models.json
 site/

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -652,7 +652,7 @@ humidifier_modules = [
         ],
         features=[HumidifierFeatures.WARM_MIST, HumidifierFeatures.AUTO_STOP],
         mist_modes={
-            HumidifierModes.AUTO: 'auto',
+            HumidifierModes.AUTO: 'humidity',
             HumidifierModes.SLEEP: 'sleep',
             HumidifierModes.MANUAL: 'manual',
         },

--- a/src/tests/api/vesynchumidifier/LUH-A602S-WUS.yaml
+++ b/src/tests/api/vesynchumidifier/LUH-A602S-WUS.yaml
@@ -14,7 +14,7 @@ set_auto_mode:
     method: bypassV2
     payload:
       data:
-        mode: auto
+        mode: humidity
       method: setHumidityMode
       source: APP
     phoneBrand: pyvesync


### PR DESCRIPTION
I got this humidifier a couple of days ago. First thing I've tried at home (after adding this to VeSync and overall initial setup) was connecting it to Home Assistant. The problem is that switching to "Auto" mode did not work there.
I've identified an error by writing a simple script that cycles through different modes. An `"auto"` option did not change anything, but `"humidity"` did switch my humidifier to the correct state.

My model number is `LUH-A602S-WEU`.
Link to the [product page](https://levoit.com/collections/levoit-lv-series-humidifiers/products/lv600s-smart-hybrid-ultrasonic-humidifier).
Screenshot from the VeSync app with modes visible.
![photo_2026-02-17_23-27-17](https://github.com/user-attachments/assets/2bb164bd-edb5-41c5-9dc1-60241311b645)
