### PR TITLE
feat: Add support for WYLDR16A1081 smart plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ pip install pyvesync
 6. Two Plug Outdoor Outlet (ESO15-TB) (Each plug is a separate `VeSyncOutlet` object, energy readings are for both plugs combined)
 7. BSDOG / Greensun Smart Outlet Series (BSDOG01, BSDOG02, WYSMTOD16A, WM-PLUG and more)
 8. WHOPLUG / Greensun Smart Outlet
+9. WYLDR Smart Plug (WYLDR16A1081) (Supports energy monitoring but not energy history)
 
 <!--SUPPORTED OUTLETS END-->
 

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -14,6 +14,7 @@ The VeSync API supports a variety of devices. The following is a list of devices
       - [Etekcity 15A Rectangle Outlet][pyvesync.devices.vesyncoutlet.VeSyncOutlet15A]
       - [Etekcity 15A Outdoor Dual Outlet][pyvesync.devices.vesyncoutlet.VeSyncOutdoorPlug]
       - [BSDOG / Greensun Smart Outlet Series][pyvesync.devices.vesyncoutlet.VeSyncBSDOGPlug] - WHOPLUG / GREENSUN
+      - [WYLDR Smart Plug][pyvesync.devices.vesyncoutlet.VeSyncBSDOGPlug] - WYLDR16A1081 (energy monitoring without energy history)
 3. Switches
       - [ESWL01][pyvesync.devices.vesyncswitch.VeSyncWallSwitch] - Etekcity Wall Switch
       - [ESWL03][pyvesync.devices.vesyncswitch.VeSyncWallSwitch] - Etekcity 3-Way Switch
@@ -59,14 +60,21 @@ Switches have minimal features, the dimmer switch is the only switch that has ad
 
 ### Outlets
 
-| Device Name | Power Stats | Nightlight |
-| :------: | :----: | :----: |
-| 7A Round Outlet | ✔ | |
-| 10A Round EU Outlet | ✔ | |
-| 10A Round US Outlet | | |
-| 15A Rectangle Outlet | ✔ | ✔ |
-| 15A Outdoor Dual Outlet | ✔ | |
-| Round Smart Series | | |
+| Device Name | Power Stats | Energy History | Nightlight |
+| :------: | :----: | :----: | :----: |
+| 7A Round Outlet | ✔ | ✔ | |
+| 10A Round EU Outlet | ✔ | ✔ | |
+| 10A Round US Outlet | | | |
+| 15A Rectangle Outlet | ✔ | ✔ | ✔ |
+| 15A Outdoor Dual Outlet | ✔ | ✔ | |
+| Smart Plug Series (WHOGPLUG / BSDOG01) | ✔ | ✔ | |
+| WYLDR Smart Plug (WYLDR16A1081) | ✔ | | |
+
+Power stats are realtime power, voltage and energy readings from the device.
+Energy history is the weekly, monthly and yearly energy usage retrieved with
+`get_weekly_energy()`, `get_monthly_energy()` and `get_yearly_energy()`. Devices
+without the energy history feature log a debug message and make no API call when
+these methods are used.
 
 ### Purifiers
 

--- a/src/pyvesync/base_devices/outlet_base.py
+++ b/src/pyvesync/base_devices/outlet_base.py
@@ -271,12 +271,24 @@ class VeSyncOutlet(VeSyncBaseToggleDevice):
         """
         return OutletFeatures.ENERGY_MONITOR in self.features
 
+    @property
+    def supports_energy_history(self) -> bool:
+        """Return True if device supports energy history retrieval.
+
+        Returns:
+            bool: True if device supports energy history, False otherwise.
+        """
+        return OutletFeatures.ENERGY_HISTORY in self.features
+
     async def get_weekly_energy(self) -> None:
         """Build weekly energy history dictionary.
 
         The data is stored in the `device.state.weekly_history` attribute
         as a `ResponseEnergyResult` object.
         """
+        if not self.supports_energy_history:
+            logger.debug('Device does not support energy history.')
+            return
         await self._get_energy_history(EnergyIntervals.WEEK)
 
     async def get_monthly_energy(self) -> None:
@@ -285,6 +297,9 @@ class VeSyncOutlet(VeSyncBaseToggleDevice):
         The data is stored in the `device.state.monthly_history` attribute
         as a `ResponseEnergyResult` object.
         """
+        if not self.supports_energy_history:
+            logger.debug('Device does not support energy history.')
+            return
         await self._get_energy_history(EnergyIntervals.MONTH)
 
     async def get_yearly_energy(self) -> None:
@@ -293,6 +308,9 @@ class VeSyncOutlet(VeSyncBaseToggleDevice):
         The data is stored in the `device.state.yearly_history` attribute
         as a `ResponseEnergyResult` object.
         """
+        if not self.supports_energy_history:
+            logger.debug('Device does not support energy history.')
+            return
         await self._get_energy_history(EnergyIntervals.YEAR)
 
     async def update_energy(self) -> None:

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -579,11 +579,13 @@ class OutletFeatures(Features):
     Attributes:
         ONOFF: Device on/off status.
         ENERGY_MONITOR: Energy monitor status.
+        ENERGY_HISTORY: Energy history retrieval support.
         NIGHTLIGHT: Nightlight status.
     """
 
     ONOFF = 'onoff'
     ENERGY_MONITOR = 'energy_monitor'
+    ENERGY_HISTORY = 'energy_history'
     NIGHTLIGHT = 'nightlight'
 
 

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -416,7 +416,7 @@ outlet_modules = [
     OutletMap(
         dev_types=['wifi-switch-1.3'],
         class_name='VeSyncOutlet7A',
-        features=[OutletFeatures.ENERGY_MONITOR],
+        features=[OutletFeatures.ENERGY_MONITOR, OutletFeatures.ENERGY_HISTORY],
         model_name='WiFi Outlet US/CA',
         model_display='ESW01-USA Series',
         setup_entry='wifi-switch-1.3',
@@ -432,7 +432,7 @@ outlet_modules = [
     OutletMap(
         dev_types=['ESW01-EU', 'ESW01-USA', 'ESW03-USA', 'ESW03-EU'],
         class_name='VeSyncOutlet10A',
-        features=[OutletFeatures.ENERGY_MONITOR],
+        features=[OutletFeatures.ENERGY_MONITOR, OutletFeatures.ENERGY_HISTORY],
         model_name='ESW03 10A WiFi Outlet',
         model_display='ESW01/03 USA/EU',
         setup_entry='ESW03',
@@ -440,7 +440,11 @@ outlet_modules = [
     OutletMap(
         dev_types=['ESW15-USA'],
         class_name='VeSyncOutlet15A',
-        features=[OutletFeatures.ENERGY_MONITOR, OutletFeatures.NIGHTLIGHT],
+        features=[
+            OutletFeatures.ENERGY_MONITOR,
+            OutletFeatures.ENERGY_HISTORY,
+            OutletFeatures.NIGHTLIGHT,
+        ],
         nightlight_modes=[NightlightModes.ON, NightlightModes.OFF, NightlightModes.AUTO],
         model_name='15A WiFi Outlet US/CA',
         model_display='ESW15-USA Series',
@@ -449,7 +453,7 @@ outlet_modules = [
     OutletMap(
         dev_types=['ESO15-TB'],
         class_name='VeSyncOutdoorPlug',
-        features=[OutletFeatures.ENERGY_MONITOR],
+        features=[OutletFeatures.ENERGY_MONITOR, OutletFeatures.ENERGY_HISTORY],
         model_name='Outdoor Plug',
         model_display='ESO15-TB Series',
         setup_entry='ESO15-TB',
@@ -459,7 +463,11 @@ outlet_modules = [
             'WHOGPLUG',
         ],
         class_name='VeSyncOutletWHOGPlug',
-        features=[OutletFeatures.ONOFF, OutletFeatures.ENERGY_MONITOR],
+        features=[
+            OutletFeatures.ONOFF,
+            OutletFeatures.ENERGY_MONITOR,
+            OutletFeatures.ENERGY_HISTORY,
+        ],
         model_name='Smart Plug',
         model_display='Smart Plug Series',
         setup_entry='WHOGPLUG',
@@ -478,7 +486,11 @@ outlet_modules = [
             'HWPLUG16',
         ],
         class_name='VeSyncBSDOGPlug',
-        features=[OutletFeatures.ONOFF, OutletFeatures.ENERGY_MONITOR],
+        features=[
+            OutletFeatures.ONOFF,
+            OutletFeatures.ENERGY_MONITOR,
+            OutletFeatures.ENERGY_HISTORY,
+        ],
         model_name='Smart Plug',
         model_display='Smart Plug Series',
         setup_entry='BSDOG01',
@@ -486,7 +498,7 @@ outlet_modules = [
     ),
     OutletMap(
         dev_types=['WYLDR16A1081'],
-        class_name='VeSyncWYLDRPlug',
+        class_name='VeSyncBSDOGPlug',
         features=[OutletFeatures.ONOFF, OutletFeatures.ENERGY_MONITOR],
         model_name='Smart Plug',
         model_display='WYLDR Smart Plug',

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -484,6 +484,15 @@ outlet_modules = [
         setup_entry='BSDOG01',
         device_alias='Smart Plug Series',
     ),
+    OutletMap(
+        dev_types=['WYLDR16A1081'],
+        class_name='VeSyncWYLDRPlug',
+        features=[OutletFeatures.ONOFF, OutletFeatures.ENERGY_MONITOR],
+        model_name='Smart Plug',
+        model_display='WYLDR Smart Plug',
+        setup_entry='WYLDR16A1081',
+        device_alias='WYLDR Smart Plug',
+    ),
 ]
 """List of ['OutletMap'][pyvesync.device_map.OutletMap] configuration
 objects for outlet devices."""

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -989,6 +989,31 @@ class VeSyncBSDOGPlug(VeSyncOutletWHOGPlug):
         return True
 
 
+class VeSyncWYLDRPlug(VeSyncBSDOGPlug):
+    """VeSync WYLDR16A1081 smart plug.
+
+    Identical to VeSyncBSDOGPlug but does not support energy history
+    (weekly/monthly) via the bypassV2 API. Calls to getEnergyHistory
+    return result code -1 for this device type.
+
+    Args:
+        details (ResponseDeviceDetailsModel): The device details.
+        manager (VeSync): The VeSync manager.
+        feature_map (OutletMap): The feature map for the device.
+
+    """
+
+    __slots__ = ()
+
+    async def _get_energy_history(self, history_interval: str) -> None:
+        """Energy history is not supported by this device type."""
+        logger.debug(
+            '%s (%s) does not support energy history retrieval',
+            self.device_name,
+            self.device_type,
+        )
+
+
 class VeSyncESW10USA(BypassV2Mixin, VeSyncOutlet):
     """VeSync ESW10 USA outlet.
 

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -1005,7 +1005,7 @@ class VeSyncWYLDRPlug(VeSyncBSDOGPlug):
 
     __slots__ = ()
 
-    async def _get_energy_history(self, history_interval: str) -> None:
+    async def _get_energy_history(self, _history_interval: str) -> None:
         """Energy history is not supported by this device type."""
         logger.debug(
             '%s (%s) does not support energy history retrieval',

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -900,6 +900,10 @@ class VeSyncOutletWHOGPlug(BypassV2Mixin, VeSyncOutlet):
 class VeSyncBSDOGPlug(VeSyncOutletWHOGPlug):
     """VeSync BSDOG01/WYZYOG smart plugs.
 
+    Also used by the WYLDR16A1081 smart plug, which shares the same API but
+    does not support energy history retrieval (its device map entry omits
+    the `OutletFeatures.ENERGY_HISTORY` feature).
+
     Args:
         details (ResponseDeviceDetailsModel): The device details.
         manager (VeSync): The VeSync manager.

--- a/src/pyvesync/devices/vesyncoutlet.py
+++ b/src/pyvesync/devices/vesyncoutlet.py
@@ -819,6 +819,9 @@ class VeSyncOutletWHOGPlug(BypassV2Mixin, VeSyncOutlet):
 
     async def _get_energy_history(self, history_interval: str | EnergyIntervals) -> None:
         """Get energy history for BSDGO1 outlet."""
+        if not self.supports_energy_history:
+            logger.debug('Device does not support energy history.')
+            return
         if history_interval not in self._energy_intervals:
             logger.error('Invalid energy history interval - %s', history_interval)
             return
@@ -850,6 +853,9 @@ class VeSyncOutletWHOGPlug(BypassV2Mixin, VeSyncOutlet):
 
     async def get_yearly_energy(self) -> None:
         """Get yearly energy for WHOG outlet."""
+        if not self.supports_energy_history:
+            logger.debug('Device does not support energy history.')
+            return
         r_dict = await self._bypass_v1_api_helper(
             RequestWHOGYearlyEnergy, method='getELECConsumePerMonthLastYear'
         )
@@ -987,31 +993,6 @@ class VeSyncBSDOGPlug(VeSyncOutletWHOGPlug):
         self.state.device_status = DeviceStatus.ON if toggle else DeviceStatus.OFF
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
-
-
-class VeSyncWYLDRPlug(VeSyncBSDOGPlug):
-    """VeSync WYLDR16A1081 smart plug.
-
-    Identical to VeSyncBSDOGPlug but does not support energy history
-    (weekly/monthly) via the bypassV2 API. Calls to getEnergyHistory
-    return result code -1 for this device type.
-
-    Args:
-        details (ResponseDeviceDetailsModel): The device details.
-        manager (VeSync): The VeSync manager.
-        feature_map (OutletMap): The feature map for the device.
-
-    """
-
-    __slots__ = ()
-
-    async def _get_energy_history(self, _history_interval: str) -> None:
-        """Energy history is not supported by this device type."""
-        logger.debug(
-            '%s (%s) does not support energy history retrieval',
-            self.device_name,
-            self.device_type,
-        )
 
 
 class VeSyncESW10USA(BypassV2Mixin, VeSyncOutlet):

--- a/src/tests/api/vesyncoutlet/WYLDR16A1081.yaml
+++ b/src/tests/api/vesyncoutlet/WYLDR16A1081.yaml
@@ -1,0 +1,91 @@
+turn_off:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: WYLDR16A1081-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: WYLDR16A1081-CID
+    method: bypassV2
+    payload:
+      data:
+        powerSwitch_1: 0
+      method: setProperty
+      source: APP
+      subDeviceNo: 0
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_on:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: WYLDR16A1081-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: WYLDR16A1081-CID
+    method: bypassV2
+    payload:
+      data:
+        powerSwitch_1: 1
+      method: setProperty
+      source: APP
+      subDeviceNo: 0
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+update:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: WYLDR16A1081-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: WYLDR16A1081-CID
+    method: bypassV2
+    payload:
+      data:
+        properties:
+        - powerSwitch_1
+        - realTimeVoltage
+        - realTimePower
+        - electricalEnergy
+        - protectionStatus
+        - voltageUpperThreshold
+        - currentUpperThreshold
+        - scheduleNum
+      method: getProperty
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2

--- a/src/tests/call_json_outlets.py
+++ b/src/tests/call_json_outlets.py
@@ -164,6 +164,7 @@ DETAILS_RESPONSES = {
     "ESO15-TB": build_bypass_v1_response(result_dict=OUTLET_DETAILS["ESO15-TB"]),
     "BSDOG01": build_bypass_v2_response(inner_result=OUTLET_DETAILS["BSDOG01"]),
     "WHOGPLUG": build_bypass_v2_response(inner_result=OUTLET_DETAILS["WHOGPLUG"]),
+    "WYLDR16A1081": build_bypass_v2_response(inner_result=OUTLET_DETAILS["BSDOG01"]),
 }
 
 
@@ -230,10 +231,11 @@ METHOD_RESPONSES = {
     "ESO15-TB": deepcopy(FunctionResponsesV1),
     "BSDOG01": deepcopy(FunctionResponsesV2),
     "WHOGPLUG": deepcopy(FunctionResponsesV2),
+    "WYLDR16A1081": deepcopy(FunctionResponsesV2),
 }
 
 for k in METHOD_RESPONSES:
-    if k in ["ESW10-USA"]:
+    if k in ["ESW10-USA", "WYLDR16A1081"]:
         METHOD_RESPONSES[k]["get_weekly_energy"] = None
         METHOD_RESPONSES[k]["get_monthly_energy"] = None
         METHOD_RESPONSES[k]["get_yearly_energy"] = None

--- a/src/tests/test_outlets.py
+++ b/src/tests/test_outlets.py
@@ -278,6 +278,14 @@ class TestOutlets(TestBase):
         if not outlet_obj.supports_energy:
             pytest.skip(f"{setup_entry} does not support energy monitoring.")
 
+        if not outlet_obj.supports_energy_history:
+            self.run_in_loop(outlet_obj.update_energy)
+            assert self.mock_api.call_count == 0
+            assert outlet_obj.state.weekly_history is None
+            assert outlet_obj.state.monthly_history is None
+            assert outlet_obj.state.yearly_history is None
+            return
+
         self.mock_api.side_effect = [
             (dict(call_json_outlets.METHOD_RESPONSES[setup_entry]['get_weekly_energy']), 200),
             (dict(call_json_outlets.METHOD_RESPONSES[setup_entry]['get_monthly_energy']), 200),


### PR DESCRIPTION
Add WYLDR16A1081 to the device map as a dedicated entry with a new VeSyncWYLDRPlug class. This device is functionally identical to the BSDOG01 series (on/off, real-time power, voltage, daily energy) but does not support energy history retrieval via the bypassV2 API — calls to getEnergyHistory return result code -1 for this device type.

VeSyncWYLDRPlug overrides _get_energy_history() with a no-op so that weekly and monthly history requests are silently skipped instead of generating spurious warning logs on every poll cycle.