### PR TITLE
fix: close event loop in teardown to prevent file descriptor leak

### DIFF
--- a/src/tests/base_test_cases.py
+++ b/src/tests/base_test_cases.py
@@ -40,7 +40,7 @@ class TestApiFunc:
         self.manager.auth._account_id = TestDefaults.account_id
         yield
         self.mock.stop()
-        self.loop.stop()
+        self.loop.close()
 
     async def run_coro(self, coro):
         """Run a coroutine in the event loop."""

--- a/src/tests/test_x_vesync_api_responses.py
+++ b/src/tests/test_x_vesync_api_responses.py
@@ -76,7 +76,7 @@ class TestApiFunc:
         self.manager.auth._account_id = TestDefaults.account_id
         yield
         self.mock.stop()
-        self.loop.stop()
+        self.loop.close()
 
     async def run_coro(self, coro):
         """Run a coroutine in the event loop."""


### PR DESCRIPTION
Using loop.stop() leaves the loop open, which can cause 'Too many open files' errors when running the test suite.