### PR TITLE
fix: wire up nightlight brightness/toggle for Sprout Humidifier (LEH-B381S)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ docstest/*
 .vesync_auth
 **/CLAUDE.md
 /docs/superpowers
+/docs/development/reviews

--- a/src/pyvesync/devices/vesynchumidifier.py
+++ b/src/pyvesync/devices/vesynchumidifier.py
@@ -1101,8 +1101,9 @@ class VeSyncSproutHumid(BypassV2Mixin, VeSyncHumidifier):
         if self.state.nightlight_color_temp is None:
             self.state.nightlight_color_temp = 3500  # Default color temp if not set
 
+        sent_brightness = brightness or self.state.nightlight_brightness or 100
         payload_data = {
-            'brightness': brightness or self.state.nightlight_brightness,
+            'brightness': sent_brightness,
             'colorTemperature': color_temp or self.state.nightlight_color_temp,
             'nightLightSwitch': int(toggle),
         }
@@ -1111,10 +1112,39 @@ class VeSyncSproutHumid(BypassV2Mixin, VeSyncHumidifier):
         if r is None:
             return False
 
-        self.state.nightlight_brightness = brightness
+        self.state.nightlight_brightness = sent_brightness
         self.state.nightlight_status = DeviceStatus.from_bool(toggle)
         self.state.connection_status = ConnectionStatus.ONLINE
         return True
+
+    async def set_nightlight_brightness(self, brightness: int) -> bool:
+        if not self.supports_nightlight_brightness:
+            logger.warning(
+                '%s is a %s does not have a nightlight or it is not supported.',
+                self.device_name,
+                self.device_type,
+            )
+            return False
+
+        if not Validators.validate_zero_to_hundred(brightness):
+            logger.warning('Brightness value must be set between 0 and 100')
+            return False
+
+        toggle = brightness > 0
+        return await self._set_nightlight_state(toggle, brightness=brightness)
+
+    async def toggle_nightlight(self, toggle: bool | None = None) -> bool:
+        if not self.supports_nightlight:
+            logger.warning(
+                '%s is a %s does not have a nightlight or it is not supported.',
+                self.device_name,
+                self.device_type,
+            )
+            return False
+
+        if toggle is None:
+            toggle = self.state.nightlight_status != DeviceStatus.ON
+        return await self._set_nightlight_state(toggle)
 
     async def toggle_automatic_stop(self, toggle: bool | None = None) -> bool:
         if toggle is None:

--- a/src/tests/api/vesynchumidifier/LEH-B381S.yaml
+++ b/src/tests/api/vesynchumidifier/LEH-B381S.yaml
@@ -108,6 +108,35 @@ set_mist_level:
     userCountryCode: US
   method: post
   url: /cloud/v2/deviceManaged/bypassV2
+set_nightlight_brightness:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: LEH-B381S-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LEH-B381S-CID
+    method: bypassV2
+    payload:
+      data:
+        brightness: 50
+        colorTemperature: 3500
+        nightLightSwitch: 1
+      method: setLightStatus
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
 turn_off:
   headers:
     Content-Type: application/json; charset=UTF-8
@@ -190,6 +219,35 @@ turn_off_display:
     userCountryCode: US
   method: post
   url: /cloud/v2/deviceManaged/bypassV2
+turn_off_nightlight:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: LEH-B381S-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LEH-B381S-CID
+    method: bypassV2
+    payload:
+      data:
+        brightness: 100
+        colorTemperature: 3500
+        nightLightSwitch: 0
+      method: setLightStatus
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
 turn_on:
   headers:
     Content-Type: application/json; charset=UTF-8
@@ -263,6 +321,35 @@ turn_on_display:
       data:
         screenSwitch: 1
       method: setDisplay
+      source: APP
+    phoneBrand: pyvesync
+    phoneOS: Android
+    timeZone: America/New_York
+    token: sample_tk
+    traceId: TRACE_ID
+    userCountryCode: US
+  method: post
+  url: /cloud/v2/deviceManaged/bypassV2
+turn_on_nightlight:
+  headers:
+    Content-Type: application/json; charset=UTF-8
+    User-Agent: okhttp/3.12.1
+  json_object:
+    acceptLanguage: en
+    accountID: sample_id
+    appVersion: 5.6.60
+    cid: LEH-B381S-CID
+    configModel: ConfigModule
+    configModule: ConfigModule
+    debugMode: false
+    deviceId: LEH-B381S-CID
+    method: bypassV2
+    payload:
+      data:
+        brightness: 100
+        colorTemperature: 3500
+        nightLightSwitch: 1
+      method: setLightStatus
       source: APP
     phoneBrand: pyvesync
     phoneOS: Android

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -125,6 +125,7 @@ class TestHumidifiers(TestBase):
             ["turn_on_nightlight"],
             ["turn_off_nightlight"],
             ["set_nightlight_brightness", {"brightness": 50}],
+        ],
         "LUH-O451S-WEU": [
             ["set_rgb_nightlight", {"power": True, "brightness": 100, "red": 252, "green": 50, "blue": 0}],
         ],

--- a/src/tests/test_humidifiers.py
+++ b/src/tests/test_humidifiers.py
@@ -121,6 +121,11 @@ class TestHumidifiers(TestBase):
         "LUH-A602S-WUS": [["set_warm_level", {"warm_level": 3}]],
         "LUH-A603S-WUS": [["set_warm_level", {"warm_level": 3}]],
         "LEH-S601S": [["turn_off_drying_mode"]],
+        "LEH-B381S": [
+            ["turn_on_nightlight"],
+            ["turn_off_nightlight"],
+            ["set_nightlight_brightness", {"brightness": 50}],
+        ],
     }
 
     def test_details(self, setup_entry, method):


### PR DESCRIPTION
## Summary

The LEH-B381S (Sprout Humidifier) already declares `NIGHTLIGHT` / `NIGHTLIGHT_BRIGHTNESS` support in `device_map.py`, and `VeSyncSproutHumid` already had a working private `_set_nightlight_state` helper that builds the correct `setLightStatus` payload. However, the class never overrode the base class's `set_nightlight_brightness` / `toggle_nightlight` methods, so any caller (e.g. Home Assistant's `select`/`switch` entities) fell through to the base-class stub, which just logs `Nightlight brightness has not been configured.` and returns `False` instead of calling the API.

Traceback this was pulled from (Home Assistant, via `select.async_select_option`):
```
File ".../vesync/select.py", line 194, in async_select_option
ERROR [pyvesync.base_devices.humidifier_base] Nightlight brightness has not been configured.
```

- Added `set_nightlight_brightness` and `toggle_nightlight` overrides to `VeSyncSproutHumid`, wired to the existing `_set_nightlight_state` helper (mirroring the pattern used in `VeSyncHumid200300S`/`VeSyncHumid1000S`).
- Fixed a latent bug in `_set_nightlight_state`: it unconditionally stored the passed-in `brightness` (including `None`) as the new state, and would send `"brightness": null` to the API when toggling the light before a brightness had ever been read or set. It now falls back to the last known brightness, or `100` if none is known yet.

## Test plan
- [x] Added `turn_on_nightlight`, `turn_off_nightlight`, and `set_nightlight_brightness` test cases for `LEH-B381S` in `test_humidifiers.py`
- [x] Recorded new API fixtures in `src/tests/api/vesynchumidifier/LEH-B381S.yaml`
- [x] `pytest src/tests/` — 355 passed, 3 skipped
- [x] `mypy src/pyvesync/devices/vesynchumidifier.py` — no issues
- [ ] Validated against a physical LEH-B381S device (reporter has the device; will confirm in this thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)