### PR TITLE
feat: Add support for Sagewe F3s202-USVC smart plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ pip install pyvesync
 7. BSDOG / Greensun Smart Outlet Series (BSDOG01, BSDOG02, WYSMTOD16A, WM-PLUG and more)
 8. WHOPLUG / Greensun Smart Outlet
 9. WYLDR Smart Plug (WYLDR16A1081) (Supports energy monitoring but not energy history)
+10. Sagewe 15A Smart Plug with Energy Monitoring (F3s202-USVC)
 
 <!--SUPPORTED OUTLETS END-->
 

--- a/docs/supported_devices.md
+++ b/docs/supported_devices.md
@@ -15,6 +15,7 @@ The VeSync API supports a variety of devices. The following is a list of devices
       - [Etekcity 15A Outdoor Dual Outlet][pyvesync.devices.vesyncoutlet.VeSyncOutdoorPlug]
       - [BSDOG / Greensun Smart Outlet Series][pyvesync.devices.vesyncoutlet.VeSyncBSDOGPlug] - WHOPLUG / GREENSUN
       - [WYLDR Smart Plug][pyvesync.devices.vesyncoutlet.VeSyncBSDOGPlug] - WYLDR16A1081 (energy monitoring without energy history)
+      - [Sagewe 15A Smart Plug][pyvesync.devices.vesyncoutlet.VeSyncOutletWHOGPlug] - F3s202-USVC
 3. Switches
       - [ESWL01][pyvesync.devices.vesyncswitch.VeSyncWallSwitch] - Etekcity Wall Switch
       - [ESWL03][pyvesync.devices.vesyncswitch.VeSyncWallSwitch] - Etekcity 3-Way Switch
@@ -69,6 +70,7 @@ Switches have minimal features, the dimmer switch is the only switch that has ad
 | 15A Outdoor Dual Outlet | ✔ | ✔ | |
 | Smart Plug Series (WHOGPLUG / BSDOG01) | ✔ | ✔ | |
 | WYLDR Smart Plug (WYLDR16A1081) | ✔ | | |
+| Sagewe Smart Plug (F3s202-USVC) | ✔ | ✔ | |
 
 Power stats are realtime power, voltage and energy readings from the device.
 Energy history is the weekly, monthly and yearly energy usage retrieved with

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -461,6 +461,7 @@ outlet_modules = [
     OutletMap(
         dev_types=[
             'WHOGPLUG',
+            'F3s202-USVC',
         ],
         class_name='VeSyncOutletWHOGPlug',
         features=[


### PR DESCRIPTION
## What

Adds the **Sagewe 15A Wi-Fi Smart Outlet Plug with Energy Monitoring** (sold under the Sagewe brand, pairs via the VeSync app) to the device map:

- `deviceType`: `F3s202-USVC`
- `configModule`: `SG_WFBO_OTL_F3s202-USVC_US`
- cid prefix: `vsot`

It is registered under the existing `WHOGPLUG` `OutletMap` entry — no new class needed.

## Why the WHOGPLUG class is correct (verified against the live API)

Probed a physical plug with both whitelabel bypassV2 dialects:

- **BSDOG dialect** — `getProperty` returns inner result code `-1` (unsupported).
- **WHOG dialect** — full support:
  - `getOutletStatus` → `{"enabled": false, "voltage": 124.02, "energy": 0, "power": 0, "current": 0}`
  - `setSwitch {"id": 0, "enabled": true}` → code 0, state reads back `enabled: true` with live load telemetry (`power: 86.8`, `current": 0.70`); off round-trip clean
  - `getEnergyHistory` (weekly + monthly) → populated `energyInfos` day buckets
  - `getELECConsumePerMonthLastYear` (yearly) → 12 populated month buckets

So the plug supports everything the `WHOGPLUG` entry claims, including `ENERGY_HISTORY`.

Tested with 21 physical units on one account; also running in Home Assistant (2026.7.2 stock `vesync` integration with this dev type patched into the device map) — switch + voltage/power/energy entities all work.

## Changes

- `src/pyvesync/device_map.py` — append `F3s202-USVC` to the `WHOGPLUG` entry's `dev_types`
- `README.md`, `docs/supported_devices.md` — list the device

No test changes: fixtures (`src/tests/api/vesyncoutlet/WHOGPLUG.yaml`) and parametrization key on `setup_entry`, and `call_json` uses `dev_types[0]`, so the appended type reuses existing WHOGPLUG coverage.

## Testing

- `pytest src/tests/` → **380 passed, 3 skipped** on this branch
- Live-API verification as above (read + write + energy history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzgVNa9W9icsjQZcmRu9J9