### PR TITLE
feat: add support for Levoit Vital Pet air purifier (LAP-P201S-WUS)

### DIFF
--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -630,14 +630,18 @@ class PurifierModes(Features):
         SLEEP: Sleep mode.
         TURBO: Turbo mode.
         PET: Pet mode.
-        ODOR_SHIELD_BALANCED: Odor Shield (balanced) mode on Levoit Vital Pet.
+        ODOR_SHIELD_QUIET: Odor Shield (quiet) auto mode on Levoit Vital Pet.
+        ODOR_SHIELD_BALANCED: Odor Shield (balanced) auto mode on Levoit Vital Pet.
+        ODOR_SHIELD_PERFORMANCE: Odor Shield (performance) auto mode on Levoit Vital Pet.
         UNKNOWN: Unknown mode.
     """
 
     AUTO = 'auto'
     MANUAL = 'manual'
     SLEEP = 'sleep'
+    ODOR_SHIELD_QUIET = 'odorShieldQuiet'
     ODOR_SHIELD_BALANCED = 'odorShieldBalanced'
+    ODOR_SHIELD_PERFORMANCE = 'odorShieldPerformance'
     TURBO = 'turbo'
     PET = 'pet'
     UNKNOWN = 'unknown'

--- a/src/pyvesync/const.py
+++ b/src/pyvesync/const.py
@@ -630,12 +630,14 @@ class PurifierModes(Features):
         SLEEP: Sleep mode.
         TURBO: Turbo mode.
         PET: Pet mode.
+        ODOR_SHIELD_BALANCED: Odor Shield (balanced) mode on Levoit Vital Pet.
         UNKNOWN: Unknown mode.
     """
 
     AUTO = 'auto'
     MANUAL = 'manual'
     SLEEP = 'sleep'
+    ODOR_SHIELD_BALANCED = 'odorShieldBalanced'
     TURBO = 'turbo'
     PET = 'pet'
     UNKNOWN = 'unknown'

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -968,6 +968,21 @@ purifier_modules: list[PurifierMap] = [
     ),
     PurifierMap(
         class_name='VeSyncAirBaseV2',
+        dev_types=['LAP-P201S-WUS'],
+        modes=[
+            PurifierModes.SLEEP,
+            PurifierModes.MANUAL,
+            PurifierModes.ODOR_SHIELD_BALANCED,
+        ],
+        features=[PurifierFeatures.AIR_QUALITY],
+        fan_levels=list(range(1, 4)),
+        device_alias='Vital Pet',
+        model_display='LAP-P201S Series',
+        model_name='Vital Pet',
+        setup_entry='LAP-P201S',
+    ),
+    PurifierMap(
+        class_name='VeSyncAirBaseV2',
         dev_types=[
             'LAP-EL551S-AUS',
             'LAP-EL551S-AEUR',

--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -972,7 +972,9 @@ purifier_modules: list[PurifierMap] = [
         modes=[
             PurifierModes.SLEEP,
             PurifierModes.MANUAL,
+            PurifierModes.ODOR_SHIELD_QUIET,
             PurifierModes.ODOR_SHIELD_BALANCED,
+            PurifierModes.ODOR_SHIELD_PERFORMANCE,
         ],
         features=[PurifierFeatures.AIR_QUALITY],
         fan_levels=list(range(1, 4)),

--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -300,9 +300,7 @@ class VeSyncAirBypass(BypassV2Mixin, VeSyncPurifier):
         return await self.set_mode(mode)
 
     async def set_mode(self, mode: str) -> bool:
-        mode_match = next(
-            (m for m in self.modes if m.lower() == mode.lower()), None
-        )
+        mode_match = next((m for m in self.modes if m.lower() == mode.lower()), None)
         if mode_match is None:
             _LOGGER.warning('Invalid purifier mode used - %s', mode)
             return False
@@ -711,9 +709,7 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         return True
 
     async def set_mode(self, mode: str) -> bool:
-        mode_match = next(
-            (m for m in self.modes if m.lower() == mode.lower()), None
-        )
+        mode_match = next((m for m in self.modes if m.lower() == mode.lower()), None)
         if mode_match is None:
             _LOGGER.warning('Invalid purifier mode used - %s', mode)
             return False

--- a/src/pyvesync/devices/vesyncpurifier.py
+++ b/src/pyvesync/devices/vesyncpurifier.py
@@ -300,9 +300,13 @@ class VeSyncAirBypass(BypassV2Mixin, VeSyncPurifier):
         return await self.set_mode(mode)
 
     async def set_mode(self, mode: str) -> bool:
-        if mode.lower() not in self.modes:
+        mode_match = next(
+            (m for m in self.modes if m.lower() == mode.lower()), None
+        )
+        if mode_match is None:
             _LOGGER.warning('Invalid purifier mode used - %s', mode)
             return False
+        mode = mode_match
 
         if mode.lower() == PurifierModes.MANUAL:
             return await self.set_fan_speed(self.state.fan_level or 1)
@@ -468,12 +472,16 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         self.state.child_lock = bool(details.childLockSwitch)
         self.state.air_quality_level = details.AQLevel
         self.state.pm25 = details.PM25
-        self.state.light_detection_switch = DeviceStatus.from_int(
-            details.lightDetectionSwitch
-        )
-        self.state.light_detection_status = DeviceStatus.from_int(
-            details.environmentLightState
-        )
+        if details.lightDetectionSwitch is not None:
+            self.state.light_detection_switch = DeviceStatus.from_int(
+                details.lightDetectionSwitch
+            )
+        if details.environmentLightState is not None:
+            self.state.light_detection_status = DeviceStatus.from_int(
+                details.environmentLightState
+            )
+        if details.VOC is not None:
+            self.state.voc = details.VOC
         self.state.display_set_status = DeviceStatus.from_int(details.screenSwitch)
         self.state.display_status = DeviceStatus.from_int(details.screenState)
         auto_pref = details.autoPreference
@@ -703,9 +711,13 @@ class VeSyncAirBaseV2(VeSyncAirBypass):
         return True
 
     async def set_mode(self, mode: str) -> bool:
-        if mode.lower() not in self.modes:
+        mode_match = next(
+            (m for m in self.modes if m.lower() == mode.lower()), None
+        )
+        if mode_match is None:
             _LOGGER.warning('Invalid purifier mode used - %s', mode)
             return False
+        mode = mode_match
 
         # Call change_fan_speed if mode is set to manual
         if mode == PurifierModes.MANUAL:

--- a/src/pyvesync/models/purifier_models.py
+++ b/src/pyvesync/models/purifier_models.py
@@ -50,18 +50,45 @@ class PurifierVitalDetailsResult(InnerPurifierBaseResult):
     screenState: int
     childLockSwitch: int
     screenSwitch: int
-    lightDetectionSwitch: int
-    environmentLightState: int
     scheduleCount: int
     timerRemain: int
-    efficientModeTimeRemain: int
     errorCode: int
+    lightDetectionSwitch: int | None = None
+    environmentLightState: int | None = None
+    efficientModeTimeRemain: int | None = None
     autoPreference: V2AutoPreferences | None = None
     fanRotateAngle: int | None = None
     filterOpenState: int | None = None
     PM1: int | None = None
     PM10: int | None = None
     AQPercent: int | None = None
+    VOC: int | None = None
+    odorLevel: int | None = None
+    buzzerSwitch: int | None = None
+    filterRemainDay: int | None = None
+    resetFilterDate: int | None = None
+    cumulativeCleanAir: int | None = None
+    totalCleanAir: int | None = None
+    errorCodes: list[int] | None = None
+    screenPreference: VitalScreenPreference | None = None
+    childLockPreference: VitalChildLockPreference | None = None
+
+
+@dataclass
+class VitalScreenPreference:
+    """Vital Pet screen preference sub-model."""
+
+    screenOnType: int
+    screenStartTime: int
+    screenEndTime: int
+
+
+@dataclass
+class VitalChildLockPreference:
+    """Vital Pet child lock preference sub-model."""
+
+    childLockAutoSwitch: int
+    childLockAutoSwitchTime: int
 
 
 @dataclass


### PR DESCRIPTION
## Add support for Levoit Vital Pet air purifier (LAP-P201S-WUS)

Adds the Levoit Vital Pet (LAP-P201S-WUS) to the purifier device map. All behavior below was validated against real hardware (US region) — mode strings were probed via `setPurifierMode` bypassV2 calls and confirmed by observing the device and the VeSync app.

### Changes

- **`device_map.py`** — new `PurifierMap` entry: `VeSyncAirBaseV2`, 3 fan levels, `AIR_QUALITY` feature, modes `sleep` / `manual` / `odorShieldQuiet` / `odorShieldBalanced` / `odorShieldPerformance`, setup entry `LAP-P201S`, alias "Vital Pet".
- **`const.py`** — new `PurifierModes` members `ODOR_SHIELD_QUIET`, `ODOR_SHIELD_BALANCED`, `ODOR_SHIELD_PERFORMANCE`. These are the device's "Auto" mode family: the app presents Auto with a Quiet/Balanced/Performance preference, and each preference is a distinct `workMode`. (`odorShieldPlus`/`autoPlus` spellings were probed and rejected by the API — the app's "Plus" appears to be a separate toggle, not a work mode.)
- **`models/purifier_models.py`** — made `lightDetectionSwitch`, `environmentLightState`, `efficientModeTimeRemain` optional (this device omits them) and added fields it returns: `VOC`, `odorLevel`, `buzzerSwitch`, `filterRemainDay`, `resetFilterDate`, `cumulativeCleanAir`, `totalCleanAir`, `errorCodes`, screen/child-lock preference objects.
- **`devices/vesyncpurifier.py`** — `set_mode()` now matches requested modes case-insensitively against the device's mode list before sending. Previously it lowercased camelCase modes (`odorshieldbalanced`), which the API rejects; this fixes mode setting for any camelCase mode while preserving validation.

### Testing

- Probed accepted/rejected `workMode` strings on hardware; only the three odorShield modes + sleep + manual are accepted.
- Round-trip verified from Home Assistant (custom component running this branch): mode changes, fan levels 1–3, display/child-lock switches, air-quality/PM2.5/filter sensors all track the VeSync app.

### Status

Draft while the device soak-tests in a live Home Assistant install for a few more days; will mark ready for review after that.
