### PR TITLE
Update device_map.py - Add support for smart plug deviceType WYLDR16A…

### DIFF
--- a/src/pyvesync/device_map.py
+++ b/src/pyvesync/device_map.py
@@ -484,6 +484,7 @@ outlet_modules = [
             'HWPLUG16A',
             'FY-PLUG',
             'HWPLUG16',
+            'WYLDR16A1081',
         ],
         class_name='VeSyncBSDOGPlug',
         features=[


### PR DESCRIPTION
Add WYLDR16A1081 smart plug to VeSyncBSDOGPlug device map

This EU smart plug is returned by the device-list API but has no entry in the device map, so pyvesync silently drops it. In Home Assistant the VeSync integration then completes setup with zero devices and no error message.

DEBUG pyvesync.device_container: Device type WYLDR16A1081 not found in device map
DEBUG pyvesync.device_container: Device type WYLDR16A1081 not found in device map
DEBUG pyvesync.vesync: Start updating the device details one by one ERROR pyvesync.vesync: No devices to update

API response for the device:

deviceType:     WYLDR16A1081
configModule:   ZY_WFBO_OTL_S_WYLDR16A1081_UN
type:           wifi-switch
connectionType: wifi+BTOnboarding
deviceRegion:   EU
deviceProp:     {"channelNum": 1, "powerSwitch_1": 1,
"thingModelVersion": 1, "connectionStatus": "online",
"protectionStatus": "normal", "wifiRssi": -49, "powerOffMemory":
"stateBeforePowerOff"}

The deviceProp structure matches the thing-model protocol already implemented by VeSyncBSDOGPlug (channelNum / powerSwitch_1 / thingModelVersion), so no new driver class is required — registering the type against the existing class is sufficient.

Verified against pyvesync 3.4.2 on two physical devices. On/off state, connection status and energy monitoring all report correctly:

name='6' type='WYLDR16A1081' class=VeSyncBSDOGPlug state=on conn=online voltage=231.27V
name='5' type='WYLDR16A1081' class=VeSyncBSDOGPlug state=on conn=online voltage=233.33V

Tested with the device-map patch applied to the installed source (no runtime monkey-patching), region EU, country DE.